### PR TITLE
Use Boost program_options to parse prmon command line

### DIFF
--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,9 +1,10 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 
 add_executable(prmon src/prmon.cpp src/prmon.h)
 target_include_directories(prmon PRIVATE RAPIDJSON_INCLUDEDIR)
-target_link_libraries(prmon Threads::Threads)
+target_link_libraries(prmon ${Boost_LIBRARIES} Threads::Threads)
 
 # - Install the example library into the install time library directory
 # The EXPORT name is used so that we can "export" the target for

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -41,7 +41,7 @@ double burn_for(float ms_interval = 1.0) {
   return burn_result;
 }
 
-int main(int argn, char *argv[]) {
+int main(int argc, char *argv[]) {
   float runtime{};
   unsigned int threads{}, procs{};
 
@@ -62,7 +62,7 @@ int main(int argn, char *argv[]) {
 
   // Parse command line
   prog_opt::variables_map var_map;
-  prog_opt::store(prog_opt::parse_command_line(argn, argv, desc), var_map);
+  prog_opt::store(prog_opt::parse_command_line(argc, argv, desc), var_map);
   prog_opt::notify(var_map);
 
   if (var_map.count("help")) {
@@ -71,7 +71,7 @@ int main(int argn, char *argv[]) {
   }
 
   if (runtime < 0.0f) {
-    std::cerr << "Program rum time cannot be negative" << std::endl;
+    std::cerr << "Program run time cannot be negative" << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
Allow for optional output filenames and polling interval.
Change signature of main MemoryMonitor() function to use
const and std::strings.

Minor rename of `argn` to `argc` in `burner.cpp` (standard var name).