### PR TITLE
Use getopt parsing for options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,23 +39,15 @@ endif()
 # Both of these issues can be resolved using CMake's compile features, see
 #
 # - https://cmake.org/cmake/help/v3.3/manual/cmake-compile-features.7.html
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-#--- Declare options -----------------------------------------------------------
-option(prmon_documentation "Whether or not to create doxygen doc target.")
 
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
 
 #--- enable CPack --------------------------------------------------------------
 include(cmake/prmonCPack.cmake)
-
-#--- target for Doxygen documentation ------------------------------------------
-if(prmon_documentation)
-  include(cmake/prmonDoxygen.cmake)
-endif()
 
 #--- add version files ---------------------------------------------------------
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prmonVersion.h

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ the resource consumption of a process and its children. This is
 useful in the context of the WLCG/HSF working group to evaluate
 the costs and performance of HEP workflows in WLCG. In a previous
 incarnation (MemoryMonitor) it has been used by ATLAS for sometime to
-gather data on resource consumption by production jobs. 
+gather data on resource consumption by production jobs. One of its
+most useful features is to use smaps to correctly calculate the
+*Proportional Set Size* in the group of processes monitored, which
+is a much better indication of the true memory consumption of
+a group of processes where children share many pages.
 
 prmon currently runs on linux machines as it requires access to the
 `/proc` interface to process statistics.
@@ -15,17 +19,23 @@ prmon currently runs on linux machines as it requires access to the
 ### Building the project
 
 Building prmon requires a modern C++ compiler, CMake version 3.1 or
-higher and the RapidJSON libraries.
+higher and the RapidJSON libraries. Note that the installation of
+RapidJSON needs to be modern enough that CMake is supported (e.g.,
+on Ubuntu 16.04 `rapidjson-dev` is too old, just install it yourself).
 
 Building should be as simple as
 
     mkdir build
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=<installdir> [-Dprmon_BUILD_DOCS=ON] <path to sources>
+    cmake -DCMAKE_INSTALL_PREFIX=<installdir> <path to sources>
     make -j<number of cores on your machine>
     make install
 
-The `prmon_BUILD_DOCS` variable is optional [placeholder - documentation is currently TODO].
+If your installation of RapidJSON is in a non-standard location then
+setting `RapidJSON_DIR` may be required as a hint to CMake.
+
+Note that in a build environment with CVMFS available the C++ compiler
+and CMake can be taken by setting up a recent LCG release.
 
 ### Creating a package with CPack
 
@@ -35,18 +45,16 @@ A cpack based package can be created by invoking
 
 ### Running the tests
 
-[Placeholder - tests are still TODO]
-
 To run the tests of the project, first build it and then invoke
 
     make test
     
 ## Running
 
-The `prmon` binary is invoked with the following arguments, all manadtory:
+The `prmon` binary is invoked with the following arguments:
 
 ```sh
-prmon --pid PPP --filename mon.txt --json-summary mon.json --interval N
+prmon --pid PPP [--filename prmon.txt] [--json-summary prmon.json] [--interval 1]
 ```
 
 * `--pid` the 'mother' PID to monitor (all children in the same process tree are monitored as well)

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
 add_executable(prmon src/prmon.cpp src/prmon.h)
-target_include_directories(prmon PRIVATE RAPIDJSON_INCLUDEDIR)
+target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 
 # - Install the example library into the install time library directory

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -288,10 +288,15 @@ int MemoryMonitor(const pid_t mpid, const std::string filename, const std::strin
 
 
 int main(int argc, char *argv[]){
+  // Set defaults
+  const char* default_filename = "prmon.txt";
+  const char* default_json_summary = "prmon.json";
+  const unsigned int default_interval = 1;
+
   pid_t pid=-1;
-  std::string filename{"prmon.txt"};
-  std::string jsonSummary{"prmon.json"};
-  unsigned int interval{1};
+  std::string filename{default_filename};
+  std::string jsonSummary{default_json_summary};
+  unsigned int interval{default_interval};
   int do_help{0};
 
   static struct option long_options[] = {
@@ -299,7 +304,7 @@ int main(int argc, char *argv[]){
       {"filename", required_argument, NULL, 'f'},
       {"json-summary", required_argument, NULL, 'j'},
       {"interval", required_argument, NULL, 'i'},
-      {"help", no_argument, &do_help, 1},
+      {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}
   };
 
@@ -321,19 +326,22 @@ int main(int argc, char *argv[]){
     case 'h':
       do_help = 1;
       break;
+    default:
+      std::cerr << "Use '--help' for usage " << std::endl;
+      return 1;
     }
   }
 
   if (do_help) {
     std::cout << "prmon is a process monitor program that records runtime data\n"
         << "from a process and its children, writing time stamped values\n"
-        << "for resource consumption into a logfile and summarises in JSON\n"
+        << "for resource consumption into a logfile and a JSON summary\n"
         << "format when the process exits.\n" << std::endl;
     std::cout << "Options:\n"
         << "--pid, -p PID             Monitored process ID\n"
-        << "[--filename, -f FILE]     Filename for detailed stats (default prmon.txt)\n"
-        << "[--json-summary, -j FILE] Filename for JSON summary (default prmon.json)\n"
-        << "[--interval, -i TIME]     Seconds between samples (default 1)\n" << std::endl;
+        << "[--filename, -f FILE]     Filename for detailed stats (default " << default_filename << ")\n"
+        << "[--json-summary, -j FILE] Filename for JSON summary (default " << default_json_summary << ")\n"
+        << "[--interval, -i TIME]     Seconds between samples (default " << default_interval << ")\n" << std::endl;
     return 0;
   }
 

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -1,10 +1,8 @@
 # CPU burner
-find_package(Boost COMPONENTS program_options REQUIRED)
 find_package(Threads REQUIRED)
 
 add_executable(burner burner.cpp)
-target_include_directories(burner PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(burner PRIVATE ${Boost_LIBRARIES} Threads::Threads)
+target_link_libraries(burner PRIVATE Threads::Threads)
 
 # Custom targets for handling scripted wrappers for tests
 function(script_install SCRIPT)

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -14,8 +14,6 @@
 
 #include "burner.h"
 
-const float default_runtime = 10.0;
-
 double burn(unsigned long iterations = 10000000lu) {
   // Perform a time wasting bit of maths
   // Use volatile to prevent the compiler from optimising away
@@ -40,20 +38,25 @@ double burn_for(float ms_interval = 1.0) {
 }
 
 int main(int argc, char *argv[]) {
-  float runtime{};
-  unsigned int threads{}, procs{};
+  // Default values
+  const float default_runtime = 10.0f;
+  const unsigned int default_threads = 1;
+  const unsigned int default_procs = 1;
+
+  float runtime{default_runtime};
+  unsigned int threads{default_threads}, procs{default_procs};
   int do_help{0};
 
   static struct option long_options[] = {
       {"threads", required_argument, NULL, 't'},
       {"procs", required_argument, NULL, 'p'},
       {"time", required_argument, NULL, 'r'},
-      {"help", no_argument, &do_help, 1},
+      {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}
   };
 
   char c;
-  while ((c = getopt_long(argc, argv, "t:p:t:h", long_options, NULL)) != -1) {
+  while ((c = getopt_long(argc, argv, "t:p:r:h", long_options, NULL)) != -1) {
     switch (c) {
     case 't':
       threads = std::stoi(optarg);
@@ -67,6 +70,9 @@ int main(int argc, char *argv[]) {
     case 'h':
       do_help = 1;
       break;
+    default:
+      std::cerr << "Use '--help' for usage" << std::endl;
+      return 1;
     }
   }
 
@@ -74,12 +80,12 @@ int main(int argc, char *argv[]) {
     std::cout <<
         "burner is a simple cpu burner program that can run in multiple threads\n"
         "and/or processes.\n\n"
-        "If both threads and procs are sepecified then each process runs\n"
+        "If both threads and procs are specified then each process runs\n"
         "multiple threads (so the load is threads * procs).\n" << std::endl;
     std::cout << "Options:\n"
-        << " [--threads, -t N]  Number of threads to run (default 1)\n"
-        << " [--procs, -p N]    Number of processes to run (default 1)\n"
-        << " [--time, -r T]     Run for T seconds (default " << default_runtime << "\n"
+        << " [--threads, -t N]  Number of threads to run (default " << default_threads << ")\n"
+        << " [--procs, -p N]    Number of processes to run (default " << default_procs << ")\n"
+        << " [--time, -r T]     Run for T seconds (default " << default_runtime << "\n\n"
         << "If threads or procs is set to 0, the hardware concurrency value is used." << std::endl;
     return 0;
   }

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -8,17 +8,15 @@
 #include <ratio>
 #include <thread>
 #include <vector>
+#include <string>
 #include <unistd.h>
-
-#include <boost/program_options.hpp>
+#include <getopt.h>
 
 #include "burner.h"
 
-namespace prog_opt = boost::program_options;
-
 const float default_runtime = 10.0;
 
-double burn(unsigned long iterations = 10'000'000lu) {
+double burn(unsigned long iterations = 10000000lu) {
   // Perform a time wasting bit of maths
   // Use volatile to prevent the compiler from optimising away
   volatile double sum{0.0};
@@ -41,33 +39,49 @@ double burn_for(float ms_interval = 1.0) {
   return burn_result;
 }
 
-int main(int argn, char *argv[]) {
+int main(int argc, char *argv[]) {
   float runtime{};
   unsigned int threads{}, procs{};
+  int do_help{0};
 
-  prog_opt::options_description desc(
-      "burner is a simple cpu burner program that can run in multiple threads\n"
-      "and/or processes.\n\n"
-      "If both threads and procs are sepecified then each process runs\n"
-      "multiple threads (so the load is threads * procs).\n\n"
-      "Allowed options:");
-  desc.add_options()
-      ("help,h", "print this help message")
-      ("threads,t", prog_opt::value<unsigned int>(&threads)->default_value(1),
-          "run in N threads (setting 0 will used the hardware concurrency value)")
-      ("procs,p", prog_opt::value<unsigned int>(&procs)->default_value(1),
-          "run in N processes (setting 0 will used the hardware concurrency value)")
-      ("time,r", prog_opt::value<float>(&runtime)->default_value(default_runtime), "run for T seconds")
-  ;
+  static struct option long_options[] = {
+      {"threads", required_argument, NULL, 't'},
+      {"procs", required_argument, NULL, 'p'},
+      {"time", required_argument, NULL, 'r'},
+      {"help", no_argument, &do_help, 1},
+      {0, 0, 0, 0}
+  };
 
-  // Parse command line
-  prog_opt::variables_map var_map;
-  prog_opt::store(prog_opt::parse_command_line(argn, argv, desc), var_map);
-  prog_opt::notify(var_map);
+  char c;
+  while ((c = getopt_long(argc, argv, "t:p:t:h", long_options, NULL)) != -1) {
+    switch (c) {
+    case 't':
+      threads = std::stoi(optarg);
+      break;
+    case 'p':
+      procs = std::stoi(optarg);
+      break;
+    case 'r':
+      runtime = std::stof(optarg);
+      break;
+    case 'h':
+      do_help = 1;
+      break;
+    }
+  }
 
-  if (var_map.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
+  if (do_help) {
+    std::cout <<
+        "burner is a simple cpu burner program that can run in multiple threads\n"
+        "and/or processes.\n\n"
+        "If both threads and procs are sepecified then each process runs\n"
+        "multiple threads (so the load is threads * procs).\n" << std::endl;
+    std::cout << "Options:\n"
+        << " [--threads, -t N]  Number of threads to run (default 1)\n"
+        << " [--procs, -p N]    Number of processes to run (default 1)\n"
+        << " [--time, -r T]     Run for T seconds (default " << default_runtime << "\n"
+        << "If threads or procs is set to 0, the hardware concurrency value is used." << std::endl;
+    return 0;
   }
 
   if (runtime < 0.0f) {


### PR DESCRIPTION
boost::program_options started to look way to heavy for a simple
stand alone utility like this, so although it's a bit more work to
use getopt, it makes the build a lot easier.

Remove the couple of places where a C++14 construct was
used, to drop the required C++ version to 11. This allows building
with compilers as old as gcc4.8 (e.g., native on CentOS7).

Fixed a bug in the way the the RapidJSON include file was passed.

Removed doxygen build elements from the CMakeLists files as
this project does not need them.

Update README.