### PR TITLE
Improve CPU time monitoring unittest

### DIFF
--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -18,7 +18,9 @@ function(script_install SCRIPT)
 	)
 endfunction(script_install)
 
-script_install(basic_prmon.sh)
+script_install(testCPU.py)
 
 # Test test
-add_test(NAME basic_prmon COMMAND basic_prmon.sh) 
+add_test(NAME testCPUsingle COMMAND testCPU.py 1 1) 
+add_test(NAME testCPUmultithread COMMAND testCPU.py 2 1) 
+add_test(NAME testCPUmultiproc COMMAND testCPU.py 1 2) 

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -21,6 +21,6 @@ endfunction(script_install)
 script_install(testCPU.py)
 
 # Test test
-add_test(NAME testCPUsingle COMMAND testCPU.py 1 1) 
-add_test(NAME testCPUmultithread COMMAND testCPU.py 2 1) 
-add_test(NAME testCPUmultiproc COMMAND testCPU.py 1 2) 
+add_test(NAME testCPUsingle COMMAND testCPU.py --threads 1 --procs 1) 
+add_test(NAME testCPUmultithread COMMAND testCPU.py --threads 2 --procs 1) 
+add_test(NAME testCPUmultiproc COMMAND testCPU.py --threads 1 --procs 2) 

--- a/package/tests/basic_prmon.sh
+++ b/package/tests/basic_prmon.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-#
-# Execute the cpu burner and check we can monitor it
-./burner --time 5 &
-../prmon --pid $! --filename test.txt --json-summary test.json --interval 1
-
-# TODO - add some check that results are what we expected

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -59,12 +59,24 @@ int main(int argc, char *argv[]) {
   while ((c = getopt_long(argc, argv, "t:p:r:h", long_options, NULL)) != -1) {
     switch (c) {
     case 't':
+      if (std::stoi(optarg) < 0) {
+        std::cerr << "threads parameter must be greater than or equal to 0 (--help for usage)" << std::endl;
+        return 1;
+      }
       threads = std::stoi(optarg);
       break;
     case 'p':
+      if (std::stoi(optarg) < 0) {
+        std::cerr << "procs parameter must be greater than or equal to 0 (--help for usage)" << std::endl;
+        return 1;
+      }
       procs = std::stoi(optarg);
       break;
     case 'r':
+      if (std::stof(optarg) <= 0) {
+        std::cerr << "runtime parameter must be greater than 0 (--help for usage)" << std::endl;
+        return 1;
+      }
       runtime = std::stof(optarg);
       break;
     case 'h':

--- a/package/tests/testCPU.py
+++ b/package/tests/testCPU.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python
+#
+# Probably we are python2, but use python3 syntax as much as possible
+from __future__ import print_function, unicode_literals
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75):
+    '''Wrap the class definition in a function to allow arguments to be passed'''
+    class configurableProcessMonitor(unittest.TestCase):
+        def test_runTestWithParams(self):
+            burn_cmd = ['./burner', '--time', str(time)]
+            if procs != 1:
+                burn_cmd.extend(['--procs', str(procs)])
+            if threads != 1:
+                burn_cmd.extend(['--threads', str(threads)])
+            burn_p = subprocess.Popen(burn_cmd, shell = False)
+    
+            prmon_cmd = ['../prmon', '--pid', str(burn_p.pid)]
+            prmon_p = subprocess.Popen(prmon_cmd, shell = False)
+    
+            burn_rc = burn_p.wait()
+            prmon_rc = prmon_p.wait()
+    
+            self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
+            prmonJSON = json.load(open("prmon.json"))
+            totCPU = prmonJSON["Max"]["totUTIME"] + prmonJSON["Max"]["totSTIME"]
+            self.assertLess(totCPU, time*threads*procs, "Too high value for CPU time")
+            self.assertGreater(totCPU, time*threads*procs*slack, "Too low value for CPU time")
+    
+    return configurableProcessMonitor
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Configurable test runner")
+    parser.add_argument('threads', type=int)
+    parser.add_argument('procs', type=int)
+    args = parser.parse_args()
+    # Stop unittest from being confused by the arguments
+    sys.argv=sys.argv[:1]
+    
+    cpm = setupConfigurableTest(args.threads,args.procs,10,0.75)
+    
+    unittest.main()


### PR DESCRIPTION
Write CPU monitor test in python as it's far easier to
check the results are sane. Add 3 tests to the CMakefile
that test single process, multi-process and multi-thead
running.

There is a bit of a weakness in the lower bound on CPU time,
as on a very busy machine it's possible that the CPU consumed
could be low, but OTOH it is a useful test that we do get some
roughly sane results.