### PR TITLE
Switch on stricter compiler checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Set the compiler to be more picky
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -Werror")
+
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -144,7 +144,6 @@ int MemoryMonitor(const pid_t mpid, const std::string filename, const std::strin
 
      unsigned long long    valuesCPU[4] = {0,0,0,0};
      unsigned long long maxValuesCPU[4] = {0,0,0,0};
-     unsigned long long avgValuesCPU[4] = {0,0,0,0};
 
      int iteration = 0;
      time_t lastIteration = time(0) - interval;

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
 
   // Each process runs the requested number of threads
   std::vector<std::thread> pool;
-  for (int i=0; i<threads; ++i)
+  for (unsigned int i=0; i<threads; ++i)
     pool.push_back(std::thread(burn_for, runtime*std::kilo::num));
   for (auto& th: pool)
     th.join();


### PR DESCRIPTION
Enable stricter checks in the compiler to make sure that we don't
have warnings - indeed treat them as errors.

Tidy up code in the places where warning conditions had crept in.

@amete - this would have caught that bug that almost came in on #20 
so it's worth doing.

I reworked the `io-burner` code a bit, but it's worth a second pair of 
eyes checking for any buffer overruns.
