### PR TITLE
Network stats added

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ most useful features is to use smaps to correctly calculate the
 is a much better indication of the true memory consumption of
 a group of processes where children share many pages.
 
-prmon currently runs on linux machines as it requires access to the
+prmon currently runs on Linux machines as it requires access to the
 `/proc` interface to process statistics.
 
 ## Build and Deployment
@@ -54,13 +54,30 @@ To run the tests of the project, first build it and then invoke
 The `prmon` binary is invoked with the following arguments:
 
 ```sh
-prmon --pid PPP [--filename prmon.txt] [--json-summary prmon.json] [--interval 1]
+prmon --pid PPP [--filename prmon.txt] [--json-summary prmon.json] [--interval 1] [--netdev DEV]
 ```
 
 * `--pid` the 'mother' PID to monitor (all children in the same process tree are monitored as well)
 * `--filename` output file for timestamped monitored values
 * `--json-summmary` output file for summary data written in JSON format
 * `--interval` time (in seconds) between monitoring snapshots
+* `--netdev` restricts network statistics to one (or more) network devices
+
+## Outputs
+
+In the `filename` output file, plain text with statistics written every
+`interval` seconds are written. The first line gives the column names.
+
+In the `json-summmary` file values for the maximum and average statistics
+are given in JSON format. This file is rewritten every `interval` seconds
+with the current summary values.
+
+Monitoring of CPU, I/O and memory is reliably accurate, at least to within
+the sampling time. Monitoring of network I/O is **not reliable** unless the
+monitored process is isolated from other processes performing network I/O
+(it gives an upper bound on the network activity, but the monitoring is
+per network device as Linux does not give per-process network data by
+default).
 
 # Copyright
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -169,7 +169,7 @@ std::vector<std::string> get_network_device_names() {
 }
 
 int read_net_stats(const std::vector<std::string> devices,
-    std::unordered_map<std::string, unsigned long long> values) {
+    std::unordered_map<std::string, unsigned long long> &values) {
   unsigned long long value_read{};
   std::string filename{};
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -10,6 +10,10 @@
 #include <rapidjson/writer.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <dirent.h>
+#include <unordered_map>
+#include <vector>
+#include <sstream>
 
 #include "prmon.h"
 
@@ -141,6 +145,49 @@ int ReadProcs(const pid_t mother_pid, unsigned long values[4],
   return 0;
 }
 
+// This is all a bit yuk, using C style directory
+// parsing. From C++17 we should use the filesystem
+// library, but only when we decide it's reasonable
+// to no longer support older compilers.
+std::vector<std::string> get_network_device_names() {
+  std::vector<std::string> devices{};
+  DIR *d;
+  struct dirent *dir;
+  const char* netdir = "/sys/class/net";
+  d = opendir(netdir);
+  if (d) {
+    while ((dir = readdir(d)) != NULL) {
+      if (!(!strcmp(dir->d_name, ".") || !strcmp(dir->d_name, "..")))
+        devices.push_back(dir->d_name);
+    }
+    closedir(d);
+  } else {
+    std::cerr << "Failed to open " << netdir << " to get list of network devices. "
+        << "No network data will be available" << std::endl;
+  }
+  return devices;
+}
+
+int read_net_stats(const std::vector<std::string> devices,
+    std::unordered_map<std::string, unsigned long long> values) {
+  unsigned long long value_read{};
+  std::string filename{};
+
+  for (auto& element : values)
+    values[element.first] = 0;
+
+  for (const auto& device: devices) {
+    for (auto& element : values) {
+      filename = "/sys/class/net/" + device + "/statistics/" + element.first;
+      std::ifstream input{filename, std::ios::binary};
+      input >> value_read;
+      values[element.first] += value_read;
+    }
+  }
+  return 0;
+}
+
+
 std::condition_variable cv;
 std::mutex cv_m;
 bool sigusr1 = false;
@@ -166,6 +213,17 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
   unsigned long long valuesCPU[4] = {0, 0, 0, 0};
   unsigned long long maxValuesCPU[4] = {0, 0, 0, 0};
 
+  const std::vector<std::string> netstats{"rx_bytes", "rx_packets", "tx_bytes", "tx_packets"};
+  std::unordered_map<std::string, unsigned long long> values_netstats_start{},
+  values_netstats{}, avg_values_netstats{};
+  for (const auto &stat: netstats) {
+    values_netstats_start.insert({stat, 0});
+    values_netstats.insert({stat, 0});
+    avg_values_netstats.insert({stat, 0});
+  }
+  std::vector<std::string> devices = get_network_device_names();
+  read_net_stats(devices, values_netstats_start);
+
   int iteration = 0;
   time_t lastIteration = time(0) - interval;
   time_t startTime;
@@ -175,19 +233,28 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
   std::ofstream file;
   file.open(filename);
   file << "Time\tVMEM\tPSS\tRSS\tSwap\trchar\twchar\trbytes\twbytes\tutime\tsti"
-          "me\tcutime\tcstime\twtime"
-       << std::endl;
+          "me\tcutime\tcstime\twtime";
+  for (const auto& stat: netstats)
+    file << "\t" << stat;
+  file << std::endl;
 
-  const char json[] =
-      "{\"Max\":  {\"maxVMEM\": 0, \"maxPSS\": 0,\"maxRSS\": 0, \"maxSwap\": "
+  // Construct string representing JSON structure
+  std::stringstream json{};
+  json << "{\"Max\":  {\"maxVMEM\": 0, \"maxPSS\": 0,\"maxRSS\": 0, \"maxSwap\": "
       "0, \"totRCHAR\": 0, \"totWCHAR\": 0,\"totRBYTES\": 0, \"totWBYTES\": 0, "
       "\"totUTIME\" : 0, \"totSTIME\" : 0, \"totCUTIME\" : 0, \"totCSTIME\" : "
-      "0, \"totWTIME\" : 0 }, \"Avg\":  {\"avgVMEM\": 0, \"avgPSS\": "
+      "0, \"totWTIME\" : 0";
+  for (const auto& stat: netstats)
+    json << ", \"" << "tot_" << stat << "\" : 0";
+  json << "}, \"Avg\":  {\"avgVMEM\": 0, \"avgPSS\": "
       "0,\"avgRSS\": 0, \"avgSwap\": 0, \"rateRCHAR\": 0, \"rateWCHAR\": "
-      "0,\"rateRBYTES\": 0, \"rateWBYTES\": 0}}";
+      "0,\"rateRBYTES\": 0, \"rateWBYTES\": 0";
+  for (const auto& stat: netstats)
+    json << ", \"" << "avg_" << stat << "\" : 0";
+  json << "}}" << std::ends;
 
   Document d;
-  d.Parse(json);
+  d.Parse(json.str().c_str());
   std::ofstream file2;  // for realtime json dict
   StringBuffer buffer;
   Writer<StringBuffer> writer(buffer);
@@ -259,6 +326,7 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
     if (time(0) - lastIteration > interval) {
       iteration = iteration + 1;
       ReadProcs(mpid, values, valuesIO, valuesCPU);
+      read_net_stats(devices, values_netstats);
 
       currentTime = time(0);
       file << currentTime << "\t" << values[0] << "\t" << values[1] << "\t"
@@ -268,7 +336,10 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
            << valuesCPU[1] * inv_clock_ticks << "\t"
            << valuesCPU[2] * inv_clock_ticks << "\t"
            << valuesCPU[3] * inv_clock_ticks << "\t"
-           << difftime(currentTime, startTime) << std::endl;
+           << difftime(currentTime, startTime);
+      for (const auto& stat: netstats)
+        file << "\t" << values_netstats[stat] - values_netstats_start[stat];
+      file << std::endl;
 
       // Compute statistics
       for (int i = 0; i < 4; i++) {
@@ -283,6 +354,11 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
 
         if (valuesCPU[i] > maxValuesCPU[i]) maxValuesCPU[i] = valuesCPU[i];
       }
+      for (const auto& stat: netstats) {
+        avg_values_netstats[stat] = static_cast<float>(values_netstats[stat] - values_netstats_start[stat])
+            /difftime(currentTime, startTime);
+      }
+
 
       // Reset buffer
       buffer.Clear();
@@ -321,6 +397,13 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
         tmp += 1;
       }
       tmp = 0;
+
+      // Network stats
+      for (const auto& stat: netstats) {
+        v1[("tot_"+stat).c_str()].SetUint64(values_netstats[stat] - values_netstats_start[stat]);
+        v2[("avg_"+stat).c_str()].SetFloat(avg_values_netstats[stat]);
+      }
+
 
       // Write JSON realtime summary to a temporary file (to avoid race
       // conditions with pilot trying to read from file at the same time)

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -2,24 +2,14 @@
   Copyright (C) 2018, CERN
 */
 
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/resource.h>
-#include <sys/stat.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <condition_variable>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <thread>
 #include <vector>
+#include <string>
 
 int ReadProcs(const pid_t mother_pid, unsigned long values[4],
               unsigned long long valuesIO[4], unsigned long long valuesCPU[4],
               const bool verbose = false);
-int MemoryMonitor(pid_t mpid, char* filename = NULL, char* jsonSummary = NULL,
-                  unsigned int interval = 600);
+int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
+                  unsigned int interval,
+                  const std::vector<std::string> netdevs);

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -8,21 +8,30 @@ add_executable(io-burner io-burner.cpp)
 target_link_libraries(io-burner PRIVATE Threads::Threads)
 
 # Custom targets for handling scripted wrappers for tests
-function(script_install SCRIPT)
+function(script_install)
+	cmake_parse_arguments(SCRIPT_INSTALL "" "SCRIPT;DESTINATION" "" ${ARGN})
+	if(NOT SCRIPT_INSTALL_SCRIPT)
+		message(FATAL "Script installer argument SCRIPT is mandatory")
+	endif(NOT SCRIPT_INSTALL_SCRIPT)
+	if(NOT SCRIPT_INSTALL_DESTINATION)
+		set(SCRIPT_INSTALL_DESTINATION ".")
+	endif(NOT SCRIPT_INSTALL_DESTINATION)
 	add_custom_command(
-		OUTPUT ${SCRIPT}
-		DEPENDS ${SCRIPT}
-		COMMAND /bin/cp ${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT} .
+		OUTPUT "${SCRIPT_INSTALL_DESTINATION}/${SCRIPT_INSTALL_SCRIPT}"
+		DEPENDS ${SCRIPT_INSTALL_SCRIPT}
+		COMMAND mkdir -p ${SCRIPT_INSTALL_DESTINATION}
+		COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT_INSTALL_SCRIPT} ${SCRIPT_INSTALL_DESTINATION}
 		VERBATIM
 	)
 	add_custom_target(
-		install_${SCRIPT} ALL
-		DEPENDS ${SCRIPT}
+		install_${SCRIPT_INSTALL_SCRIPT} ALL
+		DEPENDS ${SCRIPT_INSTALL_SCRIPT}
 	)
 endfunction(script_install)
 
-script_install(testCPU.py)
-script_install(testIO.py)
+script_install(SCRIPT testCPU.py)
+script_install(SCRIPT testIO.py)
+script_install(SCRIPT httpBlock.py DESTINATION cgi-bin)
 
 # CPU Tests
 add_test(NAME testCPUsingle COMMAND testCPU.py --threads 1 --procs 1) 

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ endfunction(script_install)
 
 script_install(SCRIPT testCPU.py)
 script_install(SCRIPT testIO.py)
+script_install(SCRIPT testNET.py)
+script_install(SCRIPT netBurner.py)
 script_install(SCRIPT httpBlock.py DESTINATION cgi-bin)
 
 # CPU Tests
@@ -42,3 +44,6 @@ add_test(NAME testCPUmultiproc COMMAND testCPU.py --threads 1 --procs 2)
 add_test(NAME basicIOsingle COMMAND testIO.py --usleep 100 --io 10)
 add_test(NAME basicIOmultithread COMMAND testIO.py --usleep 100 --io 10 --threads 2)
 add_test(NAME basicIOmultiproc COMMAND testIO.py --usleep 100 --io 10  --procs 2)
+
+# Net Tests
+add_test(NAME basicNET COMMAND python testNET.py)

--- a/package/tests/httpBlock.py
+++ b/package/tests/httpBlock.py
@@ -1,11 +1,13 @@
 #! /usr/bin/env python
 #
+# Copyright (C) CERN, 2018
+#
 # Simple CGI script that delivers a known block
 # of data to the caller over HTTP
 #
 # One GET/POST parameter is recognised, which is "blocks"
 # that specifies how many  1KB blocks are returned to the
-# client (defaults to 1000, thus 1MB delivered)
+# client (defaults to 1000, thus ~1MB delivered)
 from __future__ import print_function, unicode_literals
 
 import cgi

--- a/package/tests/httpBlock.py
+++ b/package/tests/httpBlock.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python
+#
+# Simple CGI script that delivers a known block
+# of data to the caller over HTTP
+#
+# One GET/POST parameter is recognised, which is "blocks"
+# that specifies how many  1KB blocks are returned to the
+# client (defaults to 1000, thus 1MB delivered)
+from __future__ import print_function, unicode_literals
+
+import cgi
+import cgitb
+import sys
+
+cgitb.enable()
+
+print("Content-Type: text/plain\n")
+
+form = cgi.FieldStorage()
+blocks = form.getfirst("blocks", default="1000")
+try:
+    blocks = int(blocks)
+except ValueError:
+    print("Invalid block value")
+    sys.exit(1)
+
+myString = "somehow the world seems more curious than when i was a child xx\n"
+myBlock = myString * 16 # 1KB
+
+for i in range(blocks):
+    print(myBlock)
+
+sys.exit(0)

--- a/package/tests/netBurner.py
+++ b/package/tests/netBurner.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+#
+# Copyright (C) CERN, 2018
+#
+# Request network data for prmon unittest
+#
+from __future__ import print_function, unicode_literals
+
+import argparse
+import time
+import urllib2
+
+def getNetData(host="localhost", port="8000", blocks=None):
+    url = "http://" + host + ":" + str(port) + "/cgi-bin/httpBlock.py"
+    if blocks:
+        url += "?blocks=" + str(blocks)
+    response = urllib2.urlopen(url)
+    html = response.read()
+    print("Read {0} bytes".format(len(html)))
+    return len(html)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Network data burner")
+    parser.add_argument('--port', type=int, default=8000)
+    parser.add_argument('--host', default="localhost")
+    parser.add_argument('--blocks', type=int)
+    parser.add_argument('--requests', type=int, default=10)
+    parser.add_argument('--sleep', type=float, default=0.1)
+    parser.add_argument('--pause', type=float, default=3)
+    args = parser.parse_args()
+    
+    time.sleep(args.pause)
+
+    readBytes = 0
+    for req in range(args.requests):
+        time.sleep(args.sleep)
+        readBytes += getNetData(args.host, args.port, args.blocks)
+    
+    print("Read total of {0} bytes in {1} requests".format(readBytes, args.requests))
+    time.sleep(args.pause)

--- a/package/tests/testNET.py
+++ b/package/tests/testNET.py
@@ -1,0 +1,68 @@
+#! /usr/bin/env python
+#
+# Copyright (C) CERN, 2018
+#
+# Test script for network IO
+from __future__ import print_function, unicode_literals
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import unittest
+
+def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slack=0.95):
+    '''Wrap the class definition in a function to allow arguments to be passed'''
+    class configurableProcessMonitor(unittest.TestCase):
+        def setUp(self):
+            # Start the simple python HTTP CGI server
+            httpServerCmd = ['python', '-m', 'CGIHTTPServer']
+            self.httpServer = subprocess.Popen(httpServerCmd, shell = False)
+            
+        def tearDown(self):
+            os.kill(self.httpServer.pid, signal.SIGTERM)
+
+        def test_runTestWithParams(self):
+            burn_cmd = ['python', './netBurner.py']
+            if (requests):
+                burn_cmd.extend(['--requests', str(requests)])
+            if (pause):
+                burn_cmd.extend(['--pause', str(pause)])
+            if (sleep):
+                burn_cmd.extend(['--sleep', str(sleep)])
+            if blocks:
+                burn_cmd.extend(['--blocks', str(blocks)])
+            burn_p = subprocess.Popen(burn_cmd, shell=False)    
+            prmon_cmd = ['../prmon', '--pid', str(burn_p.pid)]
+            prmon_p = subprocess.Popen(prmon_cmd, shell = False)
+    
+            burn_rc = burn_p.wait()
+            prmon_rc = prmon_p.wait()
+    
+            self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
+            prmonJSON = json.load(open("prmon.json"))
+            expectedBytes = 1025000 * requests * slack;
+            self.assertGreater(prmonJSON["Max"]["tot_rx_bytes"], expectedBytes, "Too low value for rx bytes "
+                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tot_rx_bytes"]))
+            self.assertGreater(prmonJSON["Max"]["tot_tx_bytes"], expectedBytes, "Too low value for tx bytes "
+                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tot_tx_bytes"]))
+    
+    return configurableProcessMonitor
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Configurable test runner for network access")
+    parser.add_argument('--blocks', type=int)
+    parser.add_argument('--requests', type=int, default=10)
+    parser.add_argument('--sleep', type=float)
+    parser.add_argument('--pause', type=float)
+    parser.add_argument('--slack', type=float, default=0.95)
+    args = parser.parse_args()
+    # Stop unittest from being confused by the arguments
+    sys.argv=sys.argv[:1]
+    
+    cpm = setupConfigurableTest(args.blocks, args.requests, args.sleep, args.pause, args.slack)
+    
+    unittest.main()


### PR DESCRIPTION
This adds network statistics monitoring to resolve #2.

Stats are gathered from all `/sys/class/net/DEVICE/statistics`, measuring `rx_bytes`, `rx_packets`, `tx_bytes`, `tx_packets`.

To have a unittest a small python program was written that requests data from a python localhost http server, started by the test harness. As there's no way to know what other network traffic is happening only the *minimum* expected amount of traffic is tested.
