### PR TITLE
Improve cpu burner to have short lived children

### DIFF
--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ script_install(SCRIPT httpBlock.py DESTINATION cgi-bin)
 # CPU Tests
 add_test(NAME testCPUsingle COMMAND testCPU.py --threads 1 --procs 1) 
 add_test(NAME testCPUmultithread COMMAND testCPU.py --threads 2 --procs 1) 
-add_test(NAME testCPUmultiproc COMMAND testCPU.py --threads 1 --procs 2) 
+add_test(NAME testCPUmultiproc COMMAND testCPU.py --threads 1 --procs 2 --child-fraction 0.5 --time 12) 
 add_test(NAME testCPUinvoke COMMAND testCPU.py --invoke) 
 
 # IO Tests

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -2,7 +2,10 @@
 // for testing prmon
 
 #include <getopt.h>
+#include <signal.h>
+#include <sys/wait.h>
 #include <unistd.h>
+
 #include <chrono>
 #include <cmath>
 #include <iomanip>
@@ -37,13 +40,23 @@ double burn_for(float ms_interval = 1.0) {
   return burn_result;
 }
 
+void SignalChildHandler(int /*signal*/) {
+  int status;
+  waitpid(-1, &status, 0);
+  if (status) {
+    std::cerr << "Warning, monitored child process exited with non-zero "
+    "return value: " << status << std::endl;
+  }
+}
+
 int main(int argc, char* argv[]) {
   // Default values
   const float default_runtime = 10.0f;
+  const float default_child_runtime_fraction = 1.0;
   const unsigned int default_threads = 1;
   const unsigned int default_procs = 1;
 
-  float runtime{default_runtime};
+  float runtime{default_runtime}, child_runtime_fraction{default_child_runtime_fraction};
   unsigned int threads{default_threads}, procs{default_procs};
   int do_help{0};
 
@@ -51,11 +64,12 @@ int main(int argc, char* argv[]) {
       {"threads", required_argument, NULL, 't'},
       {"procs", required_argument, NULL, 'p'},
       {"time", required_argument, NULL, 'r'},
+      {"child-fraction", required_argument, NULL, 'c'},
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
 
   char c;
-  while ((c = getopt_long(argc, argv, "t:p:r:h", long_options, NULL)) != -1) {
+  while ((c = getopt_long(argc, argv, "t:p:c:r:h", long_options, NULL)) != -1) {
     switch (c) {
       case 't':
         if (std::stoi(optarg) < 0) {
@@ -75,14 +89,23 @@ int main(int argc, char* argv[]) {
         }
         procs = std::stoi(optarg);
         break;
+      case 'c':
+        child_runtime_fraction = std::stof(optarg);
+        if (child_runtime_fraction <= 0 || child_runtime_fraction > 1.0) {
+          std::cerr
+              << "child runtime fraction must be in range (0,1.0] (--help for usage)"
+              << std::endl;
+          return 1;
+        }
+        break;
       case 'r':
-        if (std::stof(optarg) <= 0) {
+        runtime = std::stof(optarg);
+        if (runtime <= 0) {
           std::cerr
               << "runtime parameter must be greater than 0 (--help for usage)"
               << std::endl;
           return 1;
         }
-        runtime = std::stof(optarg);
         break;
       case 'h':
         do_help = 1;
@@ -106,17 +129,14 @@ int main(int argc, char* argv[]) {
               << default_threads << ")\n"
               << " [--procs, -p N]    Number of processes to run (default "
               << default_procs << ")\n"
+              << " [--child-fraction, -c F]     Run each child for a fraction F of the parent runtime (default "
+              << default_child_runtime_fraction << ")\n"
               << " [--time, -r T]     Run for T seconds (default "
               << default_runtime << ")\n\n"
               << "If threads or procs is set to 0, the hardware concurrency "
                  "value is used."
               << std::endl;
     return 0;
-  }
-
-  if (runtime < 0.0f) {
-    std::cerr << "Program rum time cannot be negative" << std::endl;
-    return 1;
   }
 
   // If threads or procs is set to zero, then use the hardware
@@ -127,21 +147,27 @@ int main(int argc, char* argv[]) {
 
   std::cout << "Will run for " << runtime << "s using " << procs
             << " process(es) and " << threads << " thread(s)" << std::endl;
+  if (child_runtime_fraction < 1.0 && procs > 1)
+    std::cout << "Children will run for " << runtime * child_runtime_fraction
+              << "s" << std::endl;
 
   // First fork child processes
+  pid_t pid = getpid();
   if (procs > 1) {
     unsigned int children{0};
-    pid_t pid{0};
-    while (children < procs - 1 && pid == 0) {
+    while (children < procs - 1 && pid != 0) {
       pid = fork();
       ++children;
     }
   }
+  if (pid)
+    signal(SIGCHLD, SignalChildHandler);
 
   // Each process runs the requested number of threads
   std::vector<std::thread> pool;
   for (unsigned int i = 0; i < threads; ++i)
-    pool.push_back(std::thread(burn_for, runtime * std::kilo::num));
+    pool.push_back(std::thread(burn_for, runtime * std::kilo::num * (pid ? 1.0 : child_runtime_fraction)));
+
   for (auto& th : pool) th.join();
 
   return 0;

--- a/package/tests/testCPU.py
+++ b/package/tests/testCPU.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import unittest
 
-def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False):
+def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, slack=0.75, invoke=False):
     '''Wrap the class definition in a function to allow arguments to be passed'''
     class configurableProcessMonitor(unittest.TestCase):
         def test_runTestWithParams(self):
@@ -19,6 +19,8 @@ def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False)
                 burn_cmd.extend(['--threads', str(threads)])
             if procs != 1:
                 burn_cmd.extend(['--procs', str(procs)])
+            if child_fraction != 1.0:
+                burn_cmd.extend(['--child-fraction', str(child_fraction)])
 
             if invoke:
                 prmon_cmd = ['../prmon', '--']
@@ -39,10 +41,11 @@ def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False)
             prmonJSON = json.load(open("prmon.json"))
             # CPU time tests
             totCPU = prmonJSON["Max"]["totUTIME"] + prmonJSON["Max"]["totSTIME"]
-            self.assertLess(totCPU, time*threads*procs, "Too high value for CPU time "
-                            "(expected maximum of {0}, got {1})".format(time*threads*procs, totCPU))
-            self.assertGreater(totCPU, time*threads*procs*slack, "Too low value for CPU time "
-                               "(expected minimum of {0}, got {1}".format(time*threads*procs*slack, totCPU))
+            expectCPU = (1.0 + (procs-1)*child_fraction) * time * threads
+            self.assertLess(totCPU, expectCPU, "Too high value for CPU time "
+                            "(expected maximum of {0}, got {1})".format(expectCPU, totCPU))
+            self.assertGreater(totCPU, expectCPU*slack, "Too low value for CPU time "
+                               "(expected minimum of {0}, got {1}".format(expectCPU*slack, totCPU))
             # Wall time tests
             totWALL = prmonJSON["Max"]["totWTIME"]
             self.assertLessEqual(totWALL, time, "Too high value for wall time "
@@ -57,6 +60,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Configurable test runner")
     parser.add_argument('--threads', type=int, default=1)
     parser.add_argument('--procs', type=int, default=1)
+    parser.add_argument('--child-fraction', type=float, default=1.0)
     parser.add_argument('--time', type=float, default=10)
     parser.add_argument('--slack', type=float, default=0.75)
     parser.add_argument('--invoke', dest='invoke', action='store_true', default=False)
@@ -65,6 +69,6 @@ if __name__ == '__main__':
     # Stop unittest from being confused by the arguments
     sys.argv=sys.argv[:1]
     
-    cpm = setupConfigurableTest(args.threads,args.procs,args.time,args.slack,args.invoke)
+    cpm = setupConfigurableTest(args.threads,args.procs,args.child_fraction,args.time,args.slack,args.invoke)
     
     unittest.main()


### PR DESCRIPTION
Add a new paramater that runs the children for a shorter time than
the parent process, to ensure that the time for already exited children
has been properly accounted for by prmon

Make multi-proc test use short child lifetime

This commit makes the CPU monitoring test *fail*, because the way
it is currently implemnted loses the CPU time information from
children who exit before the mother process (as in the previous
incarnation of the test all processes exited at the same time
this was not noticed).

(The CPU time does become accounted for in cutime and cstime,
but I am not sure why we want these to be two separate fields - it's the total that's important.)