### PR TITLE
Update the CPU usage report

### DIFF
--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -8,7 +8,7 @@
 #include <string>
 
 int ReadProcs(const pid_t mother_pid, unsigned long values[4],
-              unsigned long long valuesIO[4], unsigned long long valuesCPU[4],
+              unsigned long long valuesIO[4], unsigned long long valuesCPU[2],
               const bool verbose = false);
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
                   unsigned int interval,


### PR DESCRIPTION
The original implementation conserved the `/proc/stat` accounting, reporting parent and child CPU usage profiles separately. This meant that `utime` and `stime` were not necessarily monotonically increasing when a child exits earlier that the parent (in which case the associated usage was registered under `cutime` and `cstime`). We simply combine these to report a single monotonically increase value now (actually one for user and one for system usage).