### PR TITLE
Generic monitor re-implementation

### DIFF
--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,7 +1,12 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
-add_executable(prmon src/prmon.cpp src/netmon.cpp src/iomon.cpp src/cpumon.cpp src/wallmon.cpp)
+add_executable(prmon src/prmon.cpp
+					 src/netmon.cpp 
+					 src/iomon.cpp 
+					 src/cpumon.cpp 
+					 src/wallmon.cpp
+					 src/memmon.cpp)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
-add_executable(prmon src/prmon.cpp src/prmon.h src/netmon.cpp src/netmon.h)
+add_executable(prmon src/prmon.cpp src/prmon.h src/netmon.cpp src/netmon.h src/Imonitor.h)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
-add_executable(prmon src/prmon.cpp src/prmon.h src/netmon.cpp src/netmon.h src/Imonitor.h)
+add_executable(prmon src/prmon.cpp src/netmon.cpp src/iomon.cpp)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
-add_executable(prmon src/prmon.cpp src/netmon.cpp src/iomon.cpp src/cpumon.cpp)
+add_executable(prmon src/prmon.cpp src/netmon.cpp src/iomon.cpp src/cpumon.cpp src/wallmon.cpp)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
-add_executable(prmon src/prmon.cpp src/netmon.cpp src/iomon.cpp)
+add_executable(prmon src/prmon.cpp src/netmon.cpp src/iomon.cpp src/cpumon.cpp)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -1,0 +1,25 @@
+// Copyright (C) CERN, 2018
+//
+// Network monitoring interface class
+//
+// This is the interface class for all concrete monitoring
+// classes
+
+#ifndef PRMON_IMONITOR_H
+#define PRMON_IMONITOR_H 1
+
+#include <string>
+#include <vector>
+
+class Imonitor {
+ public:
+  virtual ~Imonitor() {};
+
+  virtual std::vector<std::string> const get_text_headers() = 0;
+  virtual std::vector<std::string> const get_json_keys() = 0;
+
+  virtual std::unordered_map<std::string, unsigned long long> read_stats() = 0;
+  virtual void read_stats(std::unordered_map<std::string, unsigned long long>& stats) = 0;
+};
+
+#endif  // PRMON_IMONITOR_H

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -8,6 +8,10 @@
 #ifndef PRMON_IMONITOR_H
 #define PRMON_IMONITOR_H 1
 
+#include <sys/types.h>
+#include <time.h>
+
+#include <map>
 #include <string>
 #include <vector>
 
@@ -15,10 +19,12 @@ class Imonitor {
  public:
   virtual ~Imonitor() {};
 
-  virtual std::vector<std::string> const get_text_headers() = 0;
-  virtual std::vector<std::string> const get_json_keys() = 0;
+  virtual void update_stats(const std::vector<pid_t>& pids) = 0;
 
-  virtual void read_stats(std::unordered_map<std::string, unsigned long long>& stats) = 0;
+  virtual std::map<std::string, unsigned long long> const get_text_stats() = 0;
+  virtual std::map<std::string, unsigned long long> const get_json_total_stats() = 0;
+  virtual std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed) = 0;
+
 };
 
 #endif  // PRMON_IMONITOR_H

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -18,7 +18,6 @@ class Imonitor {
   virtual std::vector<std::string> const get_text_headers() = 0;
   virtual std::vector<std::string> const get_json_keys() = 0;
 
-  virtual std::unordered_map<std::string, unsigned long long> read_stats() = 0;
   virtual void read_stats(std::unordered_map<std::string, unsigned long long>& stats) = 0;
 };
 

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -23,7 +23,7 @@ class Imonitor {
 
   virtual std::map<std::string, unsigned long long> const get_text_stats() = 0;
   virtual std::map<std::string, unsigned long long> const get_json_total_stats() = 0;
-  virtual std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed) = 0;
+  virtual std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks) = 0;
 
 };
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -1,0 +1,75 @@
+// Copyright (C) CERN, 2018
+
+#include "cpumon.h"
+
+#include <string.h>
+#include <unistd.h>
+
+#include <iostream>
+
+const static std::vector<std::string> default_cpu_params{
+    "utime", "stime", "cutime", "cstime"};
+
+const static unsigned int fname_size{64};
+const static unsigned int stat_buf_size{2048};
+
+const static float inv_clock_ticks = 1. / sysconf(_SC_CLK_TCK);
+
+// Constructor; uses RAII pattern to be valid
+// after construction
+cpumon::cpumon() : cpu_stats{}, pid_cpu_stats{} {
+  for (const auto& cpu_param : default_cpu_params) cpu_stats[cpu_param] = 0;
+}
+
+void cpumon::update_stats(const std::vector<pid_t>& pids) {
+  // TODO use ifstream, but need to read known strings more flexibly
+  // and tie to the vector of parameters being parsed
+  char stat_fname_buffer[fname_size];
+  char line_buffer[stat_buf_size];
+  for (const auto pid : pids) {
+    snprintf(stat_fname_buffer, fname_size, "/proc/%d/stat", pid);
+    FILE* file3 = fopen(stat_fname_buffer, "r");
+    fgets(line_buffer, 2048, file3);
+    auto tsbuffer = strchr(line_buffer, ')');
+    unsigned long long utime, stime, cutime, cstime;
+    if (sscanf(tsbuffer + 2,
+               "%*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %80llu %80llu "
+               "%80llu %80llu",
+               &utime, &stime, &cutime, &cstime)) {
+      pid_cpu_stats[pid]["utime"] = utime;
+      pid_cpu_stats[pid]["stime"] = stime;
+      pid_cpu_stats[pid]["cutime"] = cutime;
+      pid_cpu_stats[pid]["cstime"] = cstime;
+    }
+    fclose(file3);
+  }
+
+  // Now that per-PID stats are known, calculate the totals
+  for (auto& cpu_stat: cpu_stats)
+    cpu_stat.second = 0;
+  for (const auto& pid_stats : pid_cpu_stats) {
+    for (const auto& cpu_stat : pid_stats.second) {
+      cpu_stats[cpu_stat.first] += cpu_stat.second;
+    }
+  }
+  for (auto& cpu_stat: cpu_stats)
+    cpu_stat.second *= inv_clock_ticks;
+
+}
+
+// Return the summed counters
+std::map<std::string, unsigned long long> const cpumon::get_text_stats() {
+  return cpu_stats;
+}
+
+// Same for JSON
+std::map<std::string, unsigned long long> const cpumon::get_json_total_stats() {
+  return cpu_stats;
+}
+
+// For CPU time there's nothing to return for CPU
+std::map<std::string, unsigned long long> const cpumon::get_json_average_stats(
+    time_t elapsed) {
+  std::map<std::string, unsigned long long> json_average_stats{};
+  return json_average_stats;
+}

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 const static std::vector<std::string> default_cpu_params{
-    "utime", "stime", "cutime", "cstime"};
+    "utime", "stime"};
 
 const static unsigned int fname_size{64};
 const static unsigned int stat_buf_size{2048};
@@ -17,8 +17,8 @@ const static float inv_clock_ticks = 1. / sysconf(_SC_CLK_TCK);
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-cpumon::cpumon() : cpu_stats{}, pid_cpu_stats{} {
-  for (const auto& cpu_param : default_cpu_params) cpu_stats[cpu_param] = 0;
+cpumon::cpumon() : cpu_params{default_cpu_params}, cpu_stats{} {
+  for (const auto& cpu_param : cpu_params) cpu_stats[cpu_param] = 0;
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {
@@ -26,6 +26,8 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
   // and tie to the vector of parameters being parsed
   char stat_fname_buffer[fname_size];
   char line_buffer[stat_buf_size];
+  for (auto stat : cpu_stats)
+    stat.second = 0;
   for (const auto pid : pids) {
     snprintf(stat_fname_buffer, fname_size, "/proc/%d/stat", pid);
     FILE* file3 = fopen(stat_fname_buffer, "r");
@@ -36,25 +38,13 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
                "%*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %80llu %80llu "
                "%80llu %80llu",
                &utime, &stime, &cutime, &cstime)) {
-      pid_cpu_stats[pid]["utime"] = utime;
-      pid_cpu_stats[pid]["stime"] = stime;
-      pid_cpu_stats[pid]["cutime"] = cutime;
-      pid_cpu_stats[pid]["cstime"] = cstime;
+      cpu_stats["utime"] += utime+cutime;
+      cpu_stats["stime"] += stime+cstime;
     }
     fclose(file3);
   }
-
-  // Now that per-PID stats are known, calculate the totals
-  for (auto& cpu_stat: cpu_stats)
-    cpu_stat.second = 0;
-  for (const auto& pid_stats : pid_cpu_stats) {
-    for (const auto& cpu_stat : pid_stats.second) {
-      cpu_stats[cpu_stat.first] += cpu_stat.second;
-    }
-  }
-  for (auto& cpu_stat: cpu_stats)
-    cpu_stat.second *= inv_clock_ticks;
-
+  for (auto& stat : cpu_stats)
+    stat.second *= inv_clock_ticks;
 }
 
 // Return the summed counters
@@ -70,6 +60,6 @@ std::map<std::string, unsigned long long> const cpumon::get_json_total_stats() {
 // For CPU time there's nothing to return for CPU
 std::map<std::string, unsigned long long> const cpumon::get_json_average_stats(
     time_t elapsed) {
-  std::map<std::string, unsigned long long> json_average_stats{};
-  return json_average_stats;
+  std::map<std::string, unsigned long long> empty_average_stats{};
+  return empty_average_stats;
 }

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) CERN, 2018
 
 #include "cpumon.h"
+#include "utils.h"
 
 #include <string.h>
 #include <unistd.h>
@@ -9,22 +10,9 @@
 #include <iostream>
 #include <sstream>
 
-const static std::vector<std::string> default_cpu_params{
-    "utime", "stime"};
-
-const static float inv_clock_ticks = 1. / sysconf(_SC_CLK_TCK);
-
-// These constants define where in the stat entry from proc
-// we find the parameters of interest
-const size_t utime_pos = 13;
-const size_t stime_pos = 14;
-const size_t cutime_pos = 15;
-const size_t cstime_pos = 16;
-const size_t stat_read_limit = 16;
-
 // Constructor; uses RAII pattern to be valid
 // after construction
-cpumon::cpumon() : cpu_params{default_cpu_params}, cpu_stats{} {
+cpumon::cpumon() : cpu_params{prmon::default_cpu_params}, cpu_stats{} {
   for (const auto& cpu_param : cpu_params) cpu_stats[cpu_param] = 0;
 }
 
@@ -32,25 +20,25 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
   for (auto stat : cpu_stats) stat.second = 0;
 
   std::vector<std::string> stat_entries{};
-  stat_entries.reserve(stat_read_limit + 1);
+  stat_entries.reserve(prmon::stat_cpu_read_limit + 1);
   std::string tmp_str{};
   for (const auto pid : pids) {
     std::stringstream stat_fname{};
     stat_fname << "/proc/" << pid << "/stat" << std::ends;
     std::ifstream proc_stat{stat_fname.str()};
-    while (proc_stat && stat_entries.size() < stat_read_limit + 1) {
+    while (proc_stat && stat_entries.size() < prmon::stat_cpu_read_limit + 1) {
       proc_stat >> tmp_str;
       if (proc_stat) stat_entries.push_back(tmp_str);
     }
-    if (stat_entries.size() > stat_read_limit) {
-      cpu_stats["utime"] += std::stol(stat_entries[utime_pos]) +
-                            std::stol(stat_entries[cutime_pos]);
-      cpu_stats["stime"] += std::stol(stat_entries[stime_pos]) +
-                            std::stol(stat_entries[cstime_pos]);
+    if (stat_entries.size() > prmon::stat_cpu_read_limit) {
+      cpu_stats["utime"] += std::stol(stat_entries[prmon::utime_pos]) +
+                            std::stol(stat_entries[prmon::cutime_pos]);
+      cpu_stats["stime"] += std::stol(stat_entries[prmon::stime_pos]) +
+                            std::stol(stat_entries[prmon::cstime_pos]);
     }
     stat_entries.clear();
   }
-  for (auto& stat : cpu_stats) stat.second *= inv_clock_ticks;
+  for (auto& stat : cpu_stats) stat.second *= prmon::inv_clock_ticks;
 }
 
 // Return the summed counters
@@ -65,7 +53,7 @@ std::map<std::string, unsigned long long> const cpumon::get_json_total_stats() {
 
 // For CPU time there's nothing to return for an average
 std::map<std::string, unsigned long long> const cpumon::get_json_average_stats(
-    time_t elapsed) {
+    unsigned long long elapsed_clock_ticks) {
   std::map<std::string, unsigned long long> empty_average_stats{};
   return empty_average_stats;
 }

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -29,7 +29,7 @@ class cpumon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed);
+  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -1,0 +1,53 @@
+// Copyright (C) CERN, 2018
+//
+// CPU monitoring class
+//
+
+#ifndef PRMON_CPUMON_H
+#define PRMON_CPUMON_H 1
+
+#include <string>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "Imonitor.h"
+
+class cpumon final : public Imonitor {
+ private:
+  // Which network cpu paramters to measure and output key names
+  std::vector<std::string> cpu_params;
+  std::vector<std::string> json_total_keys;
+  std::vector<std::string> json_average_keys;
+
+  // Container for total stats
+  std::map<std::string, unsigned long long> cpu_stats;
+
+  // Container for per-PID stats (this is required to avoid
+  // either multiple counting the same PID or losing stats
+  // for children as they exit)
+  std::unordered_map<pid_t, std::map<std::string, unsigned long long>> pid_cpu_stats;
+
+  // Helper to map parameters to JSON keys
+  inline std::string const json_total_key(std::string param) {
+    return std::string("tot_" + param);
+  }
+
+  // Helper to map parameters to JSON keys
+  inline std::string const json_average_key(std::string param) {
+    return std::string("avg_" + param);
+  }
+
+ public:
+  cpumon();
+
+  void update_stats(const std::vector<pid_t>& pids);
+
+  // These are the stat getter methods which retrieve current statistics
+  std::map<std::string, unsigned long long> const get_text_stats();
+  std::map<std::string, unsigned long long> const get_json_total_stats();
+  std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed);
+
+};
+
+#endif  // PRMON_CPUMON_H

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -17,26 +17,9 @@ class cpumon final : public Imonitor {
  private:
   // Which network cpu paramters to measure and output key names
   std::vector<std::string> cpu_params;
-  std::vector<std::string> json_total_keys;
-  std::vector<std::string> json_average_keys;
 
   // Container for total stats
   std::map<std::string, unsigned long long> cpu_stats;
-
-  // Container for per-PID stats (this is required to avoid
-  // either multiple counting the same PID or losing stats
-  // for children as they exit)
-  std::unordered_map<pid_t, std::map<std::string, unsigned long long>> pid_cpu_stats;
-
-  // Helper to map parameters to JSON keys
-  inline std::string const json_total_key(std::string param) {
-    return std::string("tot_" + param);
-  }
-
-  // Helper to map parameters to JSON keys
-  inline std::string const json_average_key(std::string param) {
-    return std::string("avg_" + param);
-  }
 
  public:
   cpumon();

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) CERN, 2018
+
+#include "iomon.h"
+
+#include <iostream>
+
+const static std::vector<std::string> default_io_params{
+    "rchar", "wchar", "read_bytes", "write_bytes"};
+
+const static unsigned int fname_size{64};
+const static unsigned int line_buf_size{256};
+
+// Constructor; uses RAII pattern to be valid
+// after construction
+iomon::iomon() : io_stats{} {
+  for (const auto& io_param : default_io_params) io_stats[io_param] = 0;
+}
+
+void iomon::update_stats(const std::vector<pid_t>& pids) {
+  // TODO use ifstream, but need to read known strings more flexibly
+  // and tie to the vector of parameters being parsed
+  char io_fname_buffer[fname_size];
+  char line_buffer[line_buf_size];
+  unsigned long long value;
+  for (const auto pid : pids) {
+    snprintf(io_fname_buffer, fname_size, "/proc/%d/io", pid);
+    FILE* file2 = fopen(io_fname_buffer, "r");
+    if (file2 != 0) {
+      while (fgets(line_buffer, line_buf_size, file2)) {
+        if (sscanf(line_buffer, "rchar: %80llu", &value) == 1)
+          io_stats["rchar"] += value;
+        if (sscanf(line_buffer, "wchar: %80llu", &value) == 1)
+          io_stats["wchar"] += value;
+        if (sscanf(line_buffer, "read_bytes: %80llu", &value) == 1)
+          io_stats["read_bytes"] += value;
+        if (sscanf(line_buffer, "write_bytes: %80llu", &value) == 1)
+          io_stats["write_bytes"] += value;
+      }
+      fclose(file2);
+    }
+  }
+}
+
+// Return the counters
+std::map<std::string, unsigned long long> const iomon::get_text_stats() {
+  return io_stats;
+}
+
+// Same for JSON
+std::map<std::string, unsigned long long> const iomon::get_json_total_stats() {
+  return io_stats;
+}
+
+// For JSON averages, divide by elapsed time
+std::map<std::string, unsigned long long> const iomon::get_json_average_stats(
+    time_t elapsed) {
+  std::map<std::string, unsigned long long> json_average_stats{};
+  for (const auto& io_param : io_stats) {
+    json_average_stats[json_average_key(io_param.first)] =
+        io_param.second / elapsed;
+  }
+  return json_average_stats;
+}

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) CERN, 2018
 
 #include "iomon.h"
+#include "utils.h"
 
 #include <fstream>
 #include <iostream>
@@ -51,11 +52,11 @@ std::map<std::string, unsigned long long> const iomon::get_json_total_stats() {
 
 // For JSON averages, divide by elapsed time
 std::map<std::string, unsigned long long> const iomon::get_json_average_stats(
-    time_t elapsed) {
+    unsigned long long elapsed_clock_ticks) {
   std::map<std::string, unsigned long long> json_average_stats{};
   for (const auto& io_param : io_stats) {
     json_average_stats[io_param.first] =
-        io_param.second / elapsed;
+        (io_param.second * prmon::clock_ticks) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -54,7 +54,7 @@ std::map<std::string, unsigned long long> const iomon::get_json_average_stats(
     time_t elapsed) {
   std::map<std::string, unsigned long long> json_average_stats{};
   for (const auto& io_param : io_stats) {
-    json_average_stats[json_average_key(io_param.first)] =
+    json_average_stats[io_param.first] =
         io_param.second / elapsed;
   }
   return json_average_stats;

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -1,0 +1,47 @@
+// Copyright (C) CERN, 2018
+//
+// I/O monitoring class
+//
+
+#ifndef PRMON_IOMON_H
+#define PRMON_IOMON_H 1
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "Imonitor.h"
+
+class iomon final : public Imonitor {
+ private:
+  // Which network io paramters to measure and output key names
+  std::vector<std::string> io_params;
+  std::vector<std::string> json_total_keys;
+  std::vector<std::string> json_average_keys;
+
+  // Container for stats
+  std::map<std::string, unsigned long long> io_stats;
+
+  // Helper to map parameters to JSON keys
+  inline std::string const json_total_key(std::string param) {
+    return std::string("tot_" + param);
+  }
+
+  // Helper to map parameters to JSON keys
+  inline std::string const json_average_key(std::string param) {
+    return std::string("avg_" + param);
+  }
+
+ public:
+  iomon();
+
+  void update_stats(const std::vector<pid_t>& pids);
+
+  // These are the stat getter methods which retrieve current statistics
+  std::map<std::string, unsigned long long> const get_text_stats();
+  std::map<std::string, unsigned long long> const get_json_total_stats();
+  std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed);
+
+};
+
+#endif  // PRMON_IOMON_H

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -28,7 +28,7 @@ class iomon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed);
+  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -16,21 +16,9 @@ class iomon final : public Imonitor {
  private:
   // Which network io paramters to measure and output key names
   std::vector<std::string> io_params;
-  std::vector<std::string> json_total_keys;
-  std::vector<std::string> json_average_keys;
 
   // Container for stats
   std::map<std::string, unsigned long long> io_stats;
-
-  // Helper to map parameters to JSON keys
-  inline std::string const json_total_key(std::string param) {
-    return std::string("tot_" + param);
-  }
-
-  // Helper to map parameters to JSON keys
-  inline std::string const json_average_key(std::string param) {
-    return std::string("avg_" + param);
-  }
 
  public:
   iomon();

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) CERN, 2018
+
+#include "memmon.h"
+#include "utils.h"
+
+#include <string.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+// Constructor; uses RAII pattern to be valid
+// after construction
+memmon::memmon() : mem_params{prmon::default_memory_params}, iterations{0} {
+  for (const auto& mem_param : mem_params) {
+    mem_stats[mem_param] = 0;
+    mem_peak_stats[mem_param] = 0;
+    mem_average_stats[mem_param] = 0;
+    mem_total_stats[mem_param] = 0;
+  }
+}
+
+void memmon::update_stats(const std::vector<pid_t>& pids) {
+  for (auto& stat : mem_stats) stat.second = 0;
+
+  std::string key_str{}, value_str{};
+  for (const auto pid : pids) {
+    std::stringstream smaps_fname{};
+    smaps_fname << "/proc/" << pid << "/smaps" << std::ends;
+    std::ifstream smap_stat{smaps_fname.str()};
+    while (smap_stat) {
+      smap_stat >> key_str >> value_str;
+      if (smap_stat) {
+        if (key_str == "Size:") {
+          mem_stats["vmem"] += std::stol(value_str);
+        } else if (key_str == "Pss:") {
+          mem_stats["pss"] += std::stol(value_str);
+        } else if (key_str == "Rss:") {
+          mem_stats["rss"] += std::stol(value_str);
+        } else if (key_str == "Swap:") {
+          mem_stats["swap"] += std::stol(value_str);
+        }
+      }
+    }
+  }
+
+  // Update the statistics with the new snapshot values
+  ++iterations;
+  for(const auto& mem_param : mem_params) {
+    if (mem_stats[mem_param] > mem_peak_stats[mem_param])
+      mem_peak_stats[mem_param] = mem_stats[mem_param];
+    mem_total_stats[mem_param] += mem_stats[mem_param];
+    mem_average_stats[mem_param] = mem_total_stats[mem_param] / iterations;
+  }
+}
+
+// Return the summed counters
+std::map<std::string, unsigned long long> const memmon::get_text_stats() {
+  return mem_stats;
+}
+
+// For JSON totals return peaks
+std::map<std::string, unsigned long long> const memmon::get_json_total_stats() {
+  return mem_peak_stats;
+}
+
+// Average values are calculated already for us based on the iteration
+// count
+std::map<std::string, unsigned long long> const memmon::get_json_average_stats(
+    unsigned long long elapsed_clock_ticks) {
+  return mem_average_stats;
+}

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -1,0 +1,42 @@
+// Copyright (C) CERN, 2018
+//
+// Memory monitoring class
+//
+
+#ifndef PRMON_MEMMON_H
+#define PRMON_MEMMON_H 1
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "Imonitor.h"
+
+class memmon final : public Imonitor {
+ private:
+  // Which network memory parameters to measure and output key names
+  std::vector<std::string> mem_params;
+
+  // Container for total stats
+  std::map<std::string, unsigned long long> mem_stats;
+  std::map<std::string, unsigned long long> mem_peak_stats;
+  std::map<std::string, unsigned long long> mem_average_stats;
+  std::map<std::string, unsigned long long> mem_total_stats;
+
+  // Counter for number of iterations
+  unsigned long iterations;
+
+
+ public:
+  memmon();
+
+  void update_stats(const std::vector<pid_t>& pids);
+
+  // These are the stat getter methods which retrieve current statistics
+  std::map<std::string, unsigned long long> const get_text_stats();
+  std::map<std::string, unsigned long long> const get_json_total_stats();
+  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+
+};
+
+#endif  // PRMON_MEMMON_H

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) CERN, 2018
 
 #include "netmon.h"
+#include "utils.h"
 
 #include <dirent.h>
 #include <time.h>
@@ -8,14 +9,12 @@
 #include <cstring>
 #include <memory>
 
-const static std::vector<std::string> default_if_params{
-    "rx_bytes", "rx_packets", "tx_bytes", "tx_packets"};
 
 // Constructor; uses RAII pattern to open all monitored
 // network device streams and to take initial values
 // to the monitor relative differences
 netmon::netmon(std::vector<std::string> netdevs)
-    : interface_params{default_if_params},
+    : interface_params{prmon::default_network_if_params},
       network_if_streams{} {
   if (netdevs.size() == 0) {
     monitored_netdevs = get_all_network_devs();
@@ -98,10 +97,10 @@ std::map<std::string, unsigned long long> const netmon::get_json_total_stats() {
 }
 
 // For JSON averages, divide by elapsed time
-std::map<std::string, unsigned long long> const netmon::get_json_average_stats(time_t elapsed) {
+std::map<std::string, unsigned long long> const netmon::get_json_average_stats(unsigned long long elapsed_clock_ticks) {
   std::map<std::string, unsigned long long> json_average_stats = get_text_stats();
   for (auto& stat : json_average_stats) {
-    stat.second /= elapsed;
+    stat.second = (stat.second * prmon::clock_ticks) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -21,10 +21,9 @@
 
 class netmon final : public Imonitor {
  private:
-  // Which network interface paramters to measure and output key names
+  // Which network interface paramters to measure (in this simple case
+  // these are also the output key names)
   std::vector<std::string> interface_params;
-  std::vector<std::string> json_total_keys;
-  std::vector<std::string> json_average_keys;
 
   // Which network interfaces to monitor
   std::vector<std::string> monitored_netdevs;
@@ -50,16 +49,6 @@ class netmon final : public Imonitor {
                                             std::string param) {
     std::string filename = "/sys/class/net/" + device + "/statistics/" + param;
     return filename;
-  }
-
-  // Helper to map parameters to JSON keys
-  inline std::string const json_total_key(std::string param) {
-    return std::string("tot_" + param);
-  }
-
-  // Helper to map parameters to JSON keys
-  inline std::string const json_average_key(std::string param) {
-    return std::string("avg_" + param);
   }
 
   // Internal method to read "raw" network stats

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -18,7 +18,7 @@
 
 #include "Imonitor.h"
 
-class netmon : public Imonitor {
+class netmon final : public Imonitor {
  private:
   // Which network interface paramters to measure
   const std::vector<std::string> interface_params;
@@ -57,19 +57,15 @@ class netmon : public Imonitor {
   netmon(std::vector<std::string> netdevs);
   netmon() : netmon(std::vector<std::string>{}){};
 
-  std::vector<std::string> const get_text_headers() final {
+  std::vector<std::string> const get_text_headers() {
     return interface_params;
   }
 
-  std::vector<std::string> const get_json_keys() final {
+  std::vector<std::string> const get_json_keys() {
     return interface_params;
   }
 
-  std::unordered_map<std::string, unsigned long long> read_stats() final {
-    return read_network_stats();
-  }
-
-  void read_stats(std::unordered_map<std::string, unsigned long long>& values) final {
+  void read_stats(std::unordered_map<std::string, unsigned long long>& values) {
     return read_network_stats(values);
   }
 

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -66,7 +66,7 @@ class netmon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(time_t elapsed);
+  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -16,7 +16,9 @@
 #include <unordered_map>
 #include <vector>
 
-class netmon {
+#include "Imonitor.h"
+
+class netmon : public Imonitor {
  private:
   // Which network interface paramters to measure
   const std::vector<std::string> interface_params;
@@ -54,6 +56,22 @@ class netmon {
  public:
   netmon(std::vector<std::string> netdevs);
   netmon() : netmon(std::vector<std::string>{}){};
+
+  std::vector<std::string> const get_text_headers() final {
+    return interface_params;
+  }
+
+  std::vector<std::string> const get_json_keys() final {
+    return interface_params;
+  }
+
+  std::unordered_map<std::string, unsigned long long> read_stats() final {
+    return read_network_stats();
+  }
+
+  void read_stats(std::unordered_map<std::string, unsigned long long>& values) final {
+    return read_network_stats(values);
+  }
 
   const std::vector<std::string> get_interface_paramter_names() {
     return interface_params;

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -340,24 +340,14 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
         if (tmp < 4) {
           i.first->value.SetUint64(maxValues[tmp]);
           i.second->value.SetUint64(avgValues[tmp] / iteration);
+        } else if (tmp==4) {
+          // Wallclock time
+          i.first->value.SetUint64(difftime(currentTime, startTime));
         }
         tmp += 1;
       }
-      tmp = 0;
 
-      // Total CPU measurements
-      for (Value::MemberIterator it = v1.MemberBegin() + 8;
-           it != v1.MemberEnd(); ++it) {
-        if (tmp < 4) {
-          it->value.SetFloat(maxValuesCPU[tmp] * inv_clock_ticks);
-        } else {
-          it->value.SetFloat(difftime(currentTime, startTime));
-        }
-        tmp += 1;
-      }
-      tmp = 0;
-
-      // JSON statistics
+      // New style JSON statistics
       for (const auto monitor : monitors)
         for (const auto& stat : monitor->get_json_total_stats())
           v1[(stat.first).c_str()].SetUint64(stat.second);

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -266,7 +266,7 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
           v1[(stat.first).c_str()].SetUint64(stat.second);
       for (const auto monitor : monitors)
         for (const auto& stat : monitor->get_json_average_stats(
-            wall_monitor.get_wallclock()))
+            wall_monitor.get_wallclock_clock_t()))
         v2[(stat.first).c_str()].SetUint64(stat.second);
 
       // Write JSON realtime summary to a temporary file (to avoid race

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -148,10 +148,19 @@ void SignalCallbackHandler(int /*signal*/) {
 
 void SignalChildHandler(int /*signal*/) {
   int status;
-  wait3 (&status, WNOHANG, (struct rusage *)NULL );
+  waitpid(-1, &status, 0);
   if (status) {
-    std::cerr << "Warning, monitored child process exited with non-zero "
-    "return value: " << status << std::endl;
+    if (WIFEXITED(status))
+      std::clog << "Child process had non-zero return value: "
+                << WEXITSTATUS(status) << std::endl;
+    else if (WIFSIGNALED(status))
+      std::clog << "Child process exited from signal " << WTERMSIG(status)
+                << std::endl;
+    else if (WIFSTOPPED(status))
+      std::clog << "Child process was stopped by signal" << WSTOPSIG(status)
+                << std::endl;
+    else if (WIFCONTINUED(status))
+      std::clog << "Child process was continued" << std::endl;
   }
 }
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -31,22 +31,14 @@
 
 using namespace rapidjson;
 
-int ReadProcs(const pid_t mother_pid, unsigned long values[4],
-              unsigned long long valuesIO[4], unsigned long long valuesCPU[4],
-              const bool verbose) {
+std::vector<pid_t> offspring_pids(const pid_t mother_pid) {
   // Get child process IDs
   std::vector<pid_t> cpids;
   char smaps_buffer[64];
-  char io_buffer[64];
-  char stat_buffer[64];
   snprintf(smaps_buffer, 64, "pstree -A -p %ld | tr \\- \\\\n",
            (long)mother_pid);
   FILE* pipe = popen(smaps_buffer, "r");
-  if (pipe == 0) {
-    if (verbose)
-      std::cerr << "MemoryMonitor: unable to open pstree pipe!" << std::endl;
-    return 1;
-  }
+  if (pipe == 0) return cpids;
 
   char buffer[256];
   std::string result = "";
@@ -70,6 +62,19 @@ int ReadProcs(const pid_t mother_pid, unsigned long values[4],
     }
   }
   pclose(pipe);
+  return cpids;
+}
+
+int ReadProcs(const pid_t mother_pid, unsigned long values[4],
+              unsigned long long valuesIO[4], unsigned long long valuesCPU[4],
+              const bool verbose) {
+  // Get child process IDs
+  char smaps_buffer[64];
+  char io_buffer[64];
+  char stat_buffer[64];
+  char buffer[256];
+
+  std::vector<pid_t> cpids = offspring_pids(mother_pid);
 
   unsigned long tsize(0);
   unsigned long trss(0);

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -8,7 +8,7 @@
 #include <string>
 
 int ReadProcs(const std::vector<pid_t>& cpids, unsigned long values[4],
-              unsigned long long valuesIO[4], unsigned long long valuesCPU[4],
+              unsigned long long valuesCPU[4],
               const bool verbose = false);
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
                   unsigned int interval,

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -8,7 +8,6 @@
 #include <string>
 
 int ReadProcs(const std::vector<pid_t>& cpids, unsigned long values[4],
-              unsigned long long valuesCPU[4],
               const bool verbose = false);
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
                   unsigned int interval,

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <string>
 
-int ReadProcs(const pid_t mother_pid, unsigned long values[4],
+int ReadProcs(const std::vector<pid_t>& cpids, unsigned long values[4],
               unsigned long long valuesIO[4], unsigned long long valuesCPU[4],
               const bool verbose = false);
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -3,12 +3,9 @@
 */
 
 #include <sys/types.h>
-#include <unistd.h>
 #include <vector>
 #include <string>
 
-int ReadProcs(const std::vector<pid_t>& cpids, unsigned long values[4],
-              const bool verbose = false);
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
                   unsigned int interval,
                   const std::vector<std::string> netdevs);

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -25,7 +25,7 @@ namespace prmon {
   const static std::vector<std::string> default_network_if_params{
       "rx_bytes", "rx_packets", "tx_bytes", "tx_packets"};
   const static std::vector<std::string> default_wall_params{"wtime"};
-
+  const static std::vector<std::string> default_memory_params{"vmem", "pss", "rss", "swap"};
 }
 
 #endif  // PRMON_UTILS_H

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -1,0 +1,31 @@
+// Generic header for prmon utilities
+//
+
+#ifndef PRMON_UTILS_H
+#define PRMON_UTILS_H 1
+
+#include <unistd.h>
+
+namespace prmon {
+  // For conversion from second <-> clock ticks
+  const static unsigned long clock_ticks = sysconf(_SC_CLK_TCK);
+  const static float inv_clock_ticks = 1. / sysconf(_SC_CLK_TCK);
+
+  // These constants define where in the stat entry from proc
+  // we find the parameters of interest
+  const size_t utime_pos = 13;
+  const size_t stime_pos = 14;
+  const size_t cutime_pos = 15;
+  const size_t cstime_pos = 16;
+  const size_t stat_cpu_read_limit = 16;
+  const size_t uptime_pos = 21;
+
+  // Default parameter lists for monitor classes
+  const static std::vector<std::string> default_cpu_params{"utime", "stime"};
+  const static std::vector<std::string> default_network_if_params{
+      "rx_bytes", "rx_packets", "tx_bytes", "tx_packets"};
+  const static std::vector<std::string> default_wall_params{"wtime"};
+
+}
+
+#endif  // PRMON_UTILS_H

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -65,12 +65,9 @@ void wallmon::update_stats(const std::vector<pid_t>& pids) {
   walltime_stats["wtime"] = current_clock_t * prmon::inv_clock_ticks;
 }
 
-time_t const wallmon::get_wallclock() {
-  return static_cast<time_t>(walltime_stats["wtime"]);
-}
-
 unsigned long long const wallmon::get_wallclock_clock_t() {
-  return current_clock_t;
+  // Just ensure we never return a zero
+  return (current_clock_t ? current_clock_t : 1);
 }
 
 // Return the summed counters

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -45,7 +45,7 @@ int wallmon::get_mother_starttime(pid_t mother_pid) {
 }
 
 void wallmon::update_stats(const std::vector<pid_t>& pids) {
-  if (!got_mother_starttime) {
+  if (!got_mother_starttime && pids.size() > 0) {
     if (get_mother_starttime(pids[0])) {
       std::clog << "Error while reading mother starttime" << std::endl;
       return;

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) CERN, 2018
+
+#include "wallmon.h"
+
+#include <string.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+const static std::vector<std::string> default_wall_params{"wtime"};
+
+const static float inv_clock_ticks = 1. / sysconf(_SC_CLK_TCK);
+
+const size_t utime_pos = 21;
+
+// Constructor; uses RAII pattern to be valid
+// after construction
+wallmon::wallmon()
+    : start_time_clock_t{0}, current_clock_t{0}, got_mother_starttime{false} {
+  walltime_stats["wtime"] = 0;
+}
+
+int wallmon::get_mother_starttime(pid_t mother_pid) {
+  std::vector<std::string> stat_entries{};
+  stat_entries.reserve(52);
+  std::string tmp_str{};
+
+  std::stringstream stat_fname{};
+  stat_fname << "/proc/" << mother_pid << "/stat" << std::ends;
+  std::ifstream proc_stat{stat_fname.str()};
+  while (proc_stat && stat_entries.size() < utime_pos + 1) {
+    proc_stat >> tmp_str;
+    if (proc_stat) stat_entries.push_back(tmp_str);
+  }
+  if (stat_entries.size() > utime_pos) {
+    start_time_clock_t = std::stol(stat_entries[utime_pos]);
+  } else {
+    // Some error happened!
+    std::clog << "Read only " << stat_entries.size()
+              << " from mother PID stat file" << std::endl;
+    std::clog << "Stream status of " << stat_fname.str() << " is "
+              << (proc_stat ? "good" : "bad") << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+void wallmon::update_stats(const std::vector<pid_t>& pids) {
+  if (!got_mother_starttime) {
+    if (get_mother_starttime(pids[0])) {
+      std::clog << "Error while reading mother starttime" << std::endl;
+      return;
+    } else {
+      got_mother_starttime = true;
+    }
+  }
+
+  std::ifstream proc_uptime{"/proc/uptime"};
+  float uptime_sec{};
+  proc_uptime >> uptime_sec;
+  if (!proc_uptime) {
+    std::clog << "Error while reading /proc/uptime" << std::endl;
+    return;
+  }
+  current_clock_t = uptime_sec * sysconf(_SC_CLK_TCK) - start_time_clock_t;
+  walltime_stats["wtime"] = current_clock_t * inv_clock_ticks;
+}
+
+time_t const wallmon::get_wallclock() {
+  return static_cast<time_t>(walltime_stats["wtime"]);
+}
+
+unsigned long long const wallmon::get_wallclock_clock_t() {
+  return current_clock_t;
+}
+
+// Return the summed counters
+std::map<std::string, unsigned long long> const wallmon::get_text_stats() {
+  return walltime_stats;
+}
+
+// Same for JSON
+std::map<std::string, unsigned long long> const wallmon::get_json_total_stats() {
+  return walltime_stats;
+}
+
+// For walltime there's nothing to return for an average
+std::map<std::string, unsigned long long> const wallmon::get_json_average_stats(
+    time_t elapsed) {
+  std::map<std::string, unsigned long long> empty_average_stats{};
+  return empty_average_stats;
+}

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -39,8 +39,7 @@ class wallmon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
-  // Class specific method to retrieve wallclock time (as time_t or clock ticks)
-  time_t const get_wallclock();
+  // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();
 };
 

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -1,0 +1,48 @@
+// Copyright (C) CERN, 2018
+//
+// Wall time monitoring class
+//
+// This is implemented separately from cputime as for walltime
+// there is one more public getter to extract the current wallclock
+// time for use in calculating the average JSON stats
+//
+
+#ifndef PRMON_WALLMON_H
+#define PRMON_WALLMON_H 1
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Imonitor.h"
+
+class wallmon final : public Imonitor {
+ private:
+  // Container for total stat
+  std::map<std::string, unsigned long long> walltime_stats;
+
+  unsigned long long start_time_clock_t, current_clock_t;
+
+  // Only need to get the mother start time once, so use
+  // a bool to say when it's done
+  bool got_mother_starttime;
+  int get_mother_starttime(pid_t mother_pid);
+
+ public:
+  wallmon();
+
+  void update_stats(const std::vector<pid_t>& pids);
+
+  // These are the stat getter methods which retrieve current statistics
+  std::map<std::string, unsigned long long> const get_text_stats();
+  std::map<std::string, unsigned long long> const get_json_total_stats();
+  std::map<std::string, unsigned long long> const get_json_average_stats(
+      time_t elapsed);
+
+  // Class specific method to retrieve wallclock time (as time_t or clock ticks)
+  time_t const get_wallclock();
+  unsigned long long const get_wallclock_clock_t();
+};
+
+#endif  // PRMON_WALLMON_H

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -37,8 +37,7 @@ class wallmon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(
-      time_t elapsed);
+  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // Class specific method to retrieve wallclock time (as time_t or clock ticks)
   time_t const get_wallclock();

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ script_install(SCRIPT httpBlock.py DESTINATION cgi-bin)
 # CPU Tests
 add_test(NAME testCPUsingle COMMAND testCPU.py --threads 1 --procs 1) 
 add_test(NAME testCPUmultithread COMMAND testCPU.py --threads 2 --procs 1) 
-add_test(NAME testCPUmultiproc COMMAND testCPU.py --threads 1 --procs 2) 
+add_test(NAME testCPUmultiproc COMMAND testCPU.py --threads 1 --procs 2 --child-fraction 0.5 --time 12) 
 add_test(NAME testCPUinvoke COMMAND testCPU.py --invoke) 
 
 # IO Tests

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -41,12 +41,9 @@ double burn_for(float ms_interval = 1.0) {
 }
 
 void SignalChildHandler(int /*signal*/) {
-  int status;
-  waitpid(-1, &status, 0);
-  if (status) {
-    std::cerr << "Warning, monitored child process exited with non-zero "
-    "return value: " << status << std::endl;
-  }
+  pid_t pid{1};
+  while (pid>0)
+    pid = waitpid((pid_t)-1, NULL, WNOHANG);
 }
 
 int main(int argc, char* argv[]) {

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -2,7 +2,10 @@
 // for testing prmon
 
 #include <getopt.h>
+#include <signal.h>
+#include <sys/wait.h>
 #include <unistd.h>
+
 #include <chrono>
 #include <cmath>
 #include <iomanip>
@@ -37,13 +40,23 @@ double burn_for(float ms_interval = 1.0) {
   return burn_result;
 }
 
+void SignalChildHandler(int /*signal*/) {
+  int status;
+  waitpid(-1, &status, 0);
+  if (status) {
+    std::cerr << "Warning, monitored child process exited with non-zero "
+    "return value: " << status << std::endl;
+  }
+}
+
 int main(int argc, char* argv[]) {
   // Default values
   const float default_runtime = 10.0f;
+  const float default_child_runtime_fraction = 1.0;
   const unsigned int default_threads = 1;
   const unsigned int default_procs = 1;
 
-  float runtime{default_runtime};
+  float runtime{default_runtime}, child_runtime_fraction{default_child_runtime_fraction};
   unsigned int threads{default_threads}, procs{default_procs};
   int do_help{0};
 
@@ -51,11 +64,12 @@ int main(int argc, char* argv[]) {
       {"threads", required_argument, NULL, 't'},
       {"procs", required_argument, NULL, 'p'},
       {"time", required_argument, NULL, 'r'},
+      {"child-fraction", required_argument, NULL, 'c'},
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
 
   char c;
-  while ((c = getopt_long(argc, argv, "t:p:r:h", long_options, NULL)) != -1) {
+  while ((c = getopt_long(argc, argv, "t:p:c:r:h", long_options, NULL)) != -1) {
     switch (c) {
       case 't':
         if (std::stoi(optarg) < 0) {
@@ -75,14 +89,23 @@ int main(int argc, char* argv[]) {
         }
         procs = std::stoi(optarg);
         break;
+      case 'c':
+        child_runtime_fraction = std::stof(optarg);
+        if (child_runtime_fraction <= 0 || child_runtime_fraction > 1.0) {
+          std::cerr
+              << "child runtime fraction must be in range (0,1.0] (--help for usage)"
+              << std::endl;
+          return 1;
+        }
+        break;
       case 'r':
-        if (std::stof(optarg) <= 0) {
+        runtime = std::stof(optarg);
+        if (runtime <= 0) {
           std::cerr
               << "runtime parameter must be greater than 0 (--help for usage)"
               << std::endl;
           return 1;
         }
-        runtime = std::stof(optarg);
         break;
       case 'h':
         do_help = 1;
@@ -106,17 +129,14 @@ int main(int argc, char* argv[]) {
               << default_threads << ")\n"
               << " [--procs, -p N]    Number of processes to run (default "
               << default_procs << ")\n"
+              << " [--child-fraction, -c F]     Run each child for a fraction F of the parent runtime (default "
+              << default_child_runtime_fraction << ")\n"
               << " [--time, -r T]     Run for T seconds (default "
               << default_runtime << ")\n\n"
               << "If threads or procs is set to 0, the hardware concurrency "
                  "value is used."
               << std::endl;
     return 0;
-  }
-
-  if (runtime < 0.0f) {
-    std::cerr << "Program rum time cannot be negative" << std::endl;
-    return 1;
   }
 
   // If threads or procs is set to zero, then use the hardware
@@ -127,21 +147,27 @@ int main(int argc, char* argv[]) {
 
   std::cout << "Will run for " << runtime << "s using " << procs
             << " process(es) and " << threads << " thread(s)" << std::endl;
+  if (child_runtime_fraction < 1.0 && procs > 1)
+    std::cout << "Children will run for " << runtime * child_runtime_fraction
+              << "s" << std::endl;
 
   // First fork child processes
+  pid_t pid = getpid();
   if (procs > 1) {
     unsigned int children{0};
-    pid_t pid{0};
-    while (children < procs - 1 && pid == 0) {
+    while (children < procs - 1 && pid != 0) {
       pid = fork();
       ++children;
     }
   }
+  if (pid)
+    signal(SIGCHLD, SignalChildHandler);
 
   // Each process runs the requested number of threads
   std::vector<std::thread> pool;
   for (unsigned int i = 0; i < threads; ++i)
-    pool.push_back(std::thread(burn_for, runtime * std::kilo::num));
+    pool.push_back(std::thread(burn_for, runtime * std::kilo::num * (pid ? 1.0 : child_runtime_fraction)));
+
   for (auto& th : pool) th.join();
 
   return 0;

--- a/package/tests/io-burner.cpp
+++ b/package/tests/io-burner.cpp
@@ -63,19 +63,9 @@ int io_burn(unsigned long bytes_to_write, std::chrono::nanoseconds nsleep,
 }
 
 void SignalChildHandler(int /*signal*/) {
-  int status;
-  waitpid(-1, &status, 0);
-  if (status) {
-    if (WIFEXITED(status))
-      std::cerr << "Warning, monitored child process had non-zero "
-      "return value: " << WEXITSTATUS(status) << std::endl;
-    else if (WIFSIGNALED(status))
-      std::cerr << "Warning, monitored child process exited from signal "
-      << WTERMSIG(status) << std::endl;
-    else
-      std::cerr << "Warning, weird things are happening... "
-      << status << std::endl;
-  }
+  pid_t pid{1};
+  while (pid>0)
+    pid = waitpid((pid_t)-1, NULL, WNOHANG);
 }
 
 int main(int argc, char* argv[]) {

--- a/package/tests/testCPU.py
+++ b/package/tests/testCPU.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import unittest
 
-def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False):
+def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, slack=0.75, invoke=False):
     '''Wrap the class definition in a function to allow arguments to be passed'''
     class configurableProcessMonitor(unittest.TestCase):
         def test_runTestWithParams(self):
@@ -19,6 +19,8 @@ def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False)
                 burn_cmd.extend(['--threads', str(threads)])
             if procs != 1:
                 burn_cmd.extend(['--procs', str(procs)])
+            if child_fraction != 1.0:
+                burn_cmd.extend(['--child-fraction', str(child_fraction)])
 
             if invoke:
                 prmon_cmd = ['../prmon', '--']
@@ -39,10 +41,11 @@ def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False)
             prmonJSON = json.load(open("prmon.json"))
             # CPU time tests
             totCPU = prmonJSON["Max"]["utime"] + prmonJSON["Max"]["stime"]
-            self.assertLess(totCPU, time*threads*procs, "Too high value for CPU time "
-                            "(expected maximum of {0}, got {1})".format(time*threads*procs, totCPU))
-            self.assertGreater(totCPU, time*threads*procs*slack, "Too low value for CPU time "
-                               "(expected minimum of {0}, got {1}".format(time*threads*procs*slack, totCPU))
+            expectCPU = (1.0 + (procs-1)*child_fraction) * time * threads
+            self.assertLess(totCPU, expectCPU, "Too high value for CPU time "
+                            "(expected maximum of {0}, got {1})".format(expectCPU, totCPU))
+            self.assertGreater(totCPU, expectCPU*slack, "Too low value for CPU time "
+                               "(expected minimum of {0}, got {1}".format(expectCPU*slack, totCPU))
             # Wall time tests
             totWALL = prmonJSON["Max"]["wtime"]
             self.assertLessEqual(totWALL, time, "Too high value for wall time "
@@ -57,6 +60,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Configurable test runner")
     parser.add_argument('--threads', type=int, default=1)
     parser.add_argument('--procs', type=int, default=1)
+    parser.add_argument('--child-fraction', type=float, default=1.0)
     parser.add_argument('--time', type=float, default=10)
     parser.add_argument('--slack', type=float, default=0.75)
     parser.add_argument('--invoke', dest='invoke', action='store_true', default=False)
@@ -65,6 +69,6 @@ if __name__ == '__main__':
     # Stop unittest from being confused by the arguments
     sys.argv=sys.argv[:1]
     
-    cpm = setupConfigurableTest(args.threads,args.procs,args.time,args.slack,args.invoke)
+    cpm = setupConfigurableTest(args.threads,args.procs,args.child_fraction,args.time,args.slack,args.invoke)
     
     unittest.main()

--- a/package/tests/testCPU.py
+++ b/package/tests/testCPU.py
@@ -38,13 +38,13 @@ def setupConfigurableTest(threads=1, procs=1, time=10, slack=0.75, invoke=False)
             self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
             prmonJSON = json.load(open("prmon.json"))
             # CPU time tests
-            totCPU = prmonJSON["Max"]["totUTIME"] + prmonJSON["Max"]["totSTIME"]
+            totCPU = prmonJSON["Max"]["utime"] + prmonJSON["Max"]["stime"]
             self.assertLess(totCPU, time*threads*procs, "Too high value for CPU time "
                             "(expected maximum of {0}, got {1})".format(time*threads*procs, totCPU))
             self.assertGreater(totCPU, time*threads*procs*slack, "Too low value for CPU time "
                                "(expected minimum of {0}, got {1}".format(time*threads*procs*slack, totCPU))
             # Wall time tests
-            totWALL = prmonJSON["Max"]["totWTIME"]
+            totWALL = prmonJSON["Max"]["wtime"]
             self.assertLessEqual(totWALL, time, "Too high value for wall time "
                             "(expected maximum of {0}, got {1})".format(time, totWALL))
             self.assertGreaterEqual(totWALL, time*slack, "Too low value for wall time "

--- a/package/tests/testIO.py
+++ b/package/tests/testIO.py
@@ -30,10 +30,10 @@ def setupConfigurableTest(io=10, threads=1, procs=1, usleep=10, pause=1, slack=0
             self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
             prmonJSON = json.load(open("prmon.json"))
             expectedBytes = io*threads*procs*slack * 1.0e6
-            self.assertGreater(prmonJSON["Max"]["totWCHAR"], expectedBytes, "Too low value for IO bytes written "
-                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["totWCHAR"]))
-            self.assertGreater(prmonJSON["Max"]["totRCHAR"], expectedBytes, "Too low value for IO bytes read "
-                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["totRCHAR"]))
+            self.assertGreater(prmonJSON["Max"]["wchar"], expectedBytes, "Too low value for IO bytes written "
+                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["wchar"]))
+            self.assertGreater(prmonJSON["Max"]["rchar"], expectedBytes, "Too low value for IO bytes read "
+                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["rchar"]))
     
     return configurableProcessMonitor
 

--- a/package/tests/testNET.py
+++ b/package/tests/testNET.py
@@ -44,10 +44,10 @@ def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slac
             self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
             prmonJSON = json.load(open("prmon.json"))
             expectedBytes = 1025000 * requests * slack;
-            self.assertGreater(prmonJSON["Max"]["tot_rx_bytes"], expectedBytes, "Too low value for rx bytes "
-                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tot_rx_bytes"]))
-            self.assertGreater(prmonJSON["Max"]["tot_tx_bytes"], expectedBytes, "Too low value for tx bytes "
-                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tot_tx_bytes"]))
+            self.assertGreater(prmonJSON["Max"]["rx_bytes"], expectedBytes, "Too low value for rx bytes "
+                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["rx_bytes"]))
+            self.assertGreater(prmonJSON["Max"]["tx_bytes"], expectedBytes, "Too low value for tx bytes "
+                               "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tx_bytes"]))
     
     return configurableProcessMonitor
 


### PR DESCRIPTION
OK, this is a very big PR, so please take your time and have a proper look. I would look firstly at the design, before worrying about any of the details of the code.

The prosaic explanation for this is two very long bus journeys (Thursday and Sunday), with a lot of time to code, but no network access. So that I was able to go well beyond my prototype ideas for #31 and actually reimplement all of the monitoring components in the new generic way. Still it's a lot to swallow in one go and I'm sorry about that.

The core of the new design is a generic monitoring interface, `Imonitor`, which describes the interfaces needed for any monitoring component. 

- The design pattern is that the constructor is RAII, so just initialising a component gives one a "working" instance. 
- There is a polling method, `update_stats`, that takes a vector of PIDs, containing the child and parent process IDs (this is because many components need to loop over every active process). The component obviously updates its state when called.
- There are result `const` getter methods, `get_*`, which get the outputs of the monitor for each of the output *channels* that `prmon` has: viz., `get_text_stats` for the timestamped text file, `get_json_total_stats` for the JSON file `Max` dictionary and `get_json_average_stats` for the corresponding `Avg` dictionary. The latter takes a parameter, which is the number of *clock ticks* since the mother process started - this is needed for some of the monitors (the walltime monitor has a special method `wallmon::get_wallclock_clock_t` that supplies this value).

The output of all the getters is a `map` between a text key and an unsigned long long value. Each monitor can produce whatever key/value pairs it likes - they can be different for each channel (e.g., some monitors produce nothing for the JSON average channel). The keys can also be different, although in practice I did not do so in any component (in the end the final JSON structure of `value["Max"]["Param"]` does not need to to be `value["Max"]["MaxParam"]` IMO, although you might disagree - but the design can support both).

Note that there is a design *limitation* that all output values have to be of the same type, so that they can be handled uniformly. I could not think of any *easy* way to get a mixture of int types and float types and in the end I decided that as our use case is long lived monitoring, ensuring no truncation/rounding for very high values was more important than losing some precision for very low values.

In `prmon` all that is done now is to instantiate all of the monitors (using a vector of base class pointers), then each step of the monitoring is just a loop over each of the monitoring components.

I believe that this is a hugely better design as each monitoring component is self contained, making it much easier to see both what it's doing and how. It also allows the possibility of adding new monitors easily and of having runtime switches for enabling/disabling specific monitoring components.

The core `prmon.cpp` is now a lot easier to follow.

As a P.S. I am still not completely happy about how RapidJSON is used, it still seems clunky, making a string for the initial JSON structure and then dividing the document into `Max` and `Avg`. OTOH, there's enough in this PR already and I would really like your thoughts on it before rewriting absolutely **everything**.
