### PR TITLE
New child pid monitoring

### DIFF
--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -2,9 +2,7 @@
   Copyright (C) 2018, CERN
 */
 
-#include <dirent.h>
 #include <getopt.h>
-#include <math.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/types.h>


### PR DESCRIPTION
Change the way we get child process ids, by looping over the information from /proc directly. This is more reliable than invoking `pstree` and doing painful string parsing in C.

Fixes #40 and #32.