### PR TITLE
Fix bug in parsing smaps files and add memory tests

### DIFF
--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <sstream>
 
 // Constructor; uses RAII pattern to be valid
@@ -30,7 +31,10 @@ void memmon::update_stats(const std::vector<pid_t>& pids) {
     smaps_fname << "/proc/" << pid << "/smaps" << std::ends;
     std::ifstream smap_stat{smaps_fname.str()};
     while (smap_stat) {
+      // Read off the potentially interesting "key: value", then discard
+      // the rest of the line
       smap_stat >> key_str >> value_str;
+      smap_stat.ignore(std::numeric_limits<std::streamsize>::max(),'\n');
       if (smap_stat) {
         if (key_str == "Size:") {
           mem_stats["vmem"] += std::stol(value_str);

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ target_link_libraries(burner PRIVATE Threads::Threads)
 add_executable(io-burner io-burner.cpp)
 target_link_libraries(io-burner PRIVATE Threads::Threads)
 
+add_executable(mem-burner mem-burner.cpp)
+
 # Custom targets for handling scripted wrappers for tests
 function(script_install)
 	cmake_parse_arguments(SCRIPT_INSTALL "" "SCRIPT;DESTINATION" "" ${ARGN})
@@ -32,6 +34,7 @@ endfunction(script_install)
 script_install(SCRIPT testCPU.py)
 script_install(SCRIPT testIO.py)
 script_install(SCRIPT testNET.py)
+script_install(SCRIPT testMEM.py)
 script_install(SCRIPT netBurner.py)
 script_install(SCRIPT httpBlock.py DESTINATION cgi-bin)
 
@@ -48,3 +51,7 @@ add_test(NAME basicIOmultiproc COMMAND testIO.py --usleep 100 --io 10  --procs 2
 
 # Net Tests
 add_test(NAME basicNET COMMAND python testNET.py)
+
+# Memory Tests
+add_test(NAME singleMem COMMAND python testMEM.py --procs 1)
+add_test(NAME childMem COMMAND python testMEM.py --procs 4)

--- a/package/tests/mem-burner.cpp
+++ b/package/tests/mem-burner.cpp
@@ -1,0 +1,158 @@
+// Simple memory 'burner' to simulate workload
+// for testing prmon. Will allocate a large
+// memory block, and write only to a certain
+// fraction of it (test RSS vs VMEM). Children
+// can be spawned that share pages with the
+// parent (test PSS vs RSS).
+
+#include <getopt.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <ratio>
+#include <thread>
+
+void SignalChildHandler(int /*signal*/) {
+  pid_t pid{1};
+  while (pid > 0)
+    pid = waitpid((pid_t)-1, NULL, WNOHANG);
+}
+
+int main(int argc, char* argv[]) {
+  // Default values
+  const unsigned int default_malloc_mb = 10;
+  const float default_mem_write_fraction = 0.5;
+  const unsigned int default_sleep_s = 10;
+  const unsigned int default_procs = 1;
+
+  unsigned int malloc_mb{default_malloc_mb};
+  float mem_write_fraction{default_mem_write_fraction};
+  float sleep_s{default_sleep_s};
+  unsigned int procs{default_procs};
+  int do_help{0};
+
+  static struct option long_options[] = {
+      {"malloc", required_argument, NULL, 'm'},
+      {"writef", required_argument, NULL, 'f'},
+      {"sleep", required_argument, NULL, 's'},
+      {"procs", required_argument, NULL, 'p'},
+      {"help", no_argument, NULL, 'h'},
+      {0, 0, 0, 0}};
+
+  char c;
+  while ((c = getopt_long(argc, argv, "m:f:s:p:h", long_options, NULL)) != -1) {
+    switch (c) {
+      case 'm':
+        if (std::stol(optarg) < 0) {
+          std::cerr << "malloc (MB) must be greater than 0 (--help for usage)"
+                    << std::endl;
+          return 1;
+        }
+        malloc_mb = std::stol(optarg);
+        break;
+      case 'f':
+        mem_write_fraction = std::stof(optarg);
+        if (mem_write_fraction < 0.0 || mem_write_fraction > 1.0) {
+          std::cerr
+              << "memory write fraction parameter must be between 0 and 1 "
+                 "(--help for usage)"
+              << std::endl;
+          return 1;
+        }
+        break;
+      case 's':
+        if (std::stoi(optarg) < 0) {
+          std::cerr << "sleep parameter must be greater than or equal to 0 "
+                       "(--help for usage)"
+                    << std::endl;
+          return 1;
+        }
+        sleep_s = std::stoi(optarg);
+        break;
+      case 'p':
+        if (std::stoi(optarg) < 0) {
+          std::cerr << "procs parameter must be greater than or equal to 0 "
+                       "(--help for usage)"
+                    << std::endl;
+          return 1;
+        }
+        procs = std::stoi(optarg);
+        break;
+      case 'h':
+        do_help = 1;
+        break;
+      default:
+        std::cerr << "Use '--help' for usage" << std::endl;
+        return 1;
+    }
+  }
+
+  if (do_help) {
+    std::cout
+        << "mem-burner is a simple memory grabber program that is used to \n"
+        << "test prmon\n"
+        << std::endl;
+    std::cout
+        << "Options:\n"
+        << " [--malloc, -m N]    Number of megabytes of memory to allocate "
+           "(default "
+        << default_malloc_mb << "MB)\n"
+        << " [--writef, -f N]    Fraction of memory to actually write to "
+           "(default "
+        << default_mem_write_fraction << ")\n"
+        << " [--procs, -p N]     Number of processes to run (default "
+        << default_procs << ")\n"
+        << " [--sleep, -s N]    Sleep (in seconds) before terminating "
+        << default_sleep_s << ")\n"
+        << "If procs is set to 0, the hardware concurrency "
+           "value is used."
+        << std::endl;
+    return 0;
+  }
+
+  // If threads or procs is set to zero, then use the hardware
+  // concurrency value
+  auto hw = std::thread::hardware_concurrency();
+  if (procs == 0) procs = hw;
+
+  std::cout << "Will allocate " << malloc_mb << "MB of memory and write to "
+            << mem_write_fraction << " of it ("
+            << malloc_mb * mem_write_fraction << "MB); " << procs
+            << " processes will be used." << std::endl;
+
+  // Allocate memory block and write to only some of it
+  unsigned long malloc_bytes = malloc_mb * std::mega::num;
+  unsigned long write_bytes = malloc_bytes * mem_write_fraction;
+
+  uint8_t* mem_block;
+  if (!(mem_block = (uint8_t*)std::malloc(malloc_bytes))) {
+    std::cerr << "Malloc of " << malloc_bytes << " failed." << std::endl;
+    return 1;
+  }
+
+  for (unsigned long i = 0; i < write_bytes; ++i) mem_block[i] = 0xaa;
+
+  // Now fork child processes, these will
+  // do nothing special, so they share the malloc
+  // block with their parent
+  pid_t pid = getpid();
+  unsigned int children{0};
+  if (procs > 1) {
+    while (children < procs - 1 && pid != 0) {
+      pid = fork();
+      ++children;
+    }
+  }
+
+  // Parent should respond to child exits
+  if (pid) signal(SIGCHLD, SignalChildHandler);
+
+  // Now sleep and exit
+  sleep(sleep_s);
+  std::free(mem_block);
+
+  return 0;
+}

--- a/package/tests/testMEM.py
+++ b/package/tests/testMEM.py
@@ -1,0 +1,66 @@
+#! /usr/bin/env python
+#
+# Probably we are python2, but use python3 syntax as much as possible
+from __future__ import print_function, unicode_literals
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+
+def setupConfigurableTest(procs=4, malloc_mb = 100, write_fraction=0.5, sleep=10, slack=0.9):
+    '''Wrap the class definition in a function to allow arguments to be passed'''
+    class configurableProcessMonitor(unittest.TestCase):
+        def checkMemoryLimits(self, name, value, expected, slack):
+            max_value = expected * (1.0 + (1.0-slack))
+            min_value = expected * slack
+            self.assertLess(value, max_value, "Too high a value for {0} "
+                                    "(expected maximum of {1}, got {2})".format(name, max_value, value))
+            self.assertGreater(value, min_value, "Too low a value for {0} "
+                                    "(expected maximum of {1}, got {2})".format(name, min_value, value))
+
+        def test_runTestWithParams(self):
+            burn_cmd = ['./mem-burner', '--sleep', str(sleep), '--malloc', str(malloc_mb), '--writef', str(write_fraction)]
+            if procs != 1:
+                burn_cmd.extend(['--procs', str(procs)])
+
+            prmon_cmd = ['../prmon', '--']
+            prmon_cmd.extend(burn_cmd)
+            prmon_p = subprocess.Popen(prmon_cmd, shell = False)
+
+            prmon_rc = prmon_p.wait()
+    
+            self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
+            prmonJSON = json.load(open("prmon.json"))
+            # Memory tests
+            vmemExpect = malloc_mb * procs * 1024 + 10000 * procs # Small uplift for program itself
+            self.checkMemoryLimits("vmem", prmonJSON["Max"]["vmem"], vmemExpect, slack)
+
+            rssExpect = malloc_mb * procs * 1024 * write_fraction
+            self.checkMemoryLimits("rss", prmonJSON["Max"]["rss"], rssExpect, slack)
+
+            pssExpect = malloc_mb * 1024 * write_fraction
+            self.checkMemoryLimits("pss", prmonJSON["Max"]["pss"], pssExpect, slack)
+
+    
+    return configurableProcessMonitor
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Configurable memory test runner")
+    parser.add_argument('--procs', type=int, default=4)
+    parser.add_argument('--malloc', type=int, default=100)
+    parser.add_argument('--writef', type=float, default=0.5)
+    parser.add_argument('--sleep', type=int, default=10)
+    parser.add_argument('--slack', type=float, default=0.9)
+
+    args = parser.parse_args()
+    # Stop unittest from being confused by the arguments
+    sys.argv=sys.argv[:1]
+    
+    cpm = setupConfigurableTest(args.procs,args.malloc,args.writef,args.sleep,args.slack)
+    
+    unittest.main()


### PR DESCRIPTION
smaps file was being processed without resetting to the
beginning of the line when trying to get key:value pairs.
Now after the k:v read the rest of the line is ignored.
This should fix #47 .

Add a mem-burner program that allocates memory, writes
to only some of it and forks some child processes. This can test
prmon's measurements of vmem, rss and pss. Add two
unit tests for single process and multi process cases.