### PR TITLE
Add option to diff yvars in the plotting script 

### DIFF
--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -30,7 +30,11 @@ if '__main__' in __name__:
                                ' (comma seperated list is accepted)')
     parser.add_argument('--stacked', dest = 'stacked', action = 'store_true',
                         help = 'stack plots if specified')
+    parser.add_argument('--diff', dest = 'diff', action = 'store_true',
+                        help = 'take discrete difference of elements for yvars '
+                        ' if specified')
     parser.set_defaults(stacked = False)
+    parser.set_defaults(diff = False)
     args = parser.parse_args()
 
     # Check the input file exists
@@ -58,13 +62,17 @@ if '__main__' in __name__:
     for carg in ylist:
         if ylabel: ylabel += '_'
         ylabel += carg.lower()
+    if args.diff: ylabel = 'diff_' + ylabel
     output = 'PrMon_%s_vs_%s.png'%(xlabel,ylabel)
 
     fig, ax1 = plt.subplots()
     xdata = np.array(data[xlabel])
     ydlist = []
     for carg in ylist:
-        ydlist.append(np.array(data[carg]))
+        if args.diff:
+            ydlist.append(np.array(data[carg].diff()))
+        else:
+            ydlist.append(np.array(data[carg]))
     if args.stacked:
         ydata = np.vstack(ydlist)
         plt.stackplot(xdata, ydata, lw = 2, labels = ylist, alpha = 0.6) 

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -70,7 +70,10 @@ if '__main__' in __name__:
     ydlist = []
     for carg in ylist:
         if args.diff:
-            ydlist.append(np.array(data[carg].diff()))
+            num = np.array(data[carg].diff())
+            denom = np.array(data[xlabel].diff())
+            ratio = np.where(denom != 0, num/denom, np.nan)
+            ydlist.append(ratio)
         else:
             ydlist.append(np.array(data[carg]))
     if args.stacked:


### PR DESCRIPTION
This PR updates the plotting script to allow the user to take discrete difference of elements for `yvars`. It's particularly useful to visualize the rate of change in variables such as the CPU time, which can be directly correlated to `Nproc*Nthread` (times the sampling time). An example plot looks like this:

![prmon_wtime_vs_diff_wtime_utime_stime](https://user-images.githubusercontent.com/7428938/40617451-9f6e1e44-628e-11e8-83d0-83300fd998a9.png)

This shows the results of a q431 test that ran on 4 cores monitored with a sampling interval of 30 seconds. Then, the plateau in the CPU user time essentially corresponds to the event-loop where we have 4*30 sec = 120 sec. I suppose we can also normalize this w/ the monitoring interval but it's essentially the same piece of information.