### PR TITLE
Change default interval to 30s for monitoring

### DIFF
--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[]) {
   // Set defaults
   const char* default_filename = "prmon.txt";
   const char* default_json_summary = "prmon.json";
-  const unsigned int default_interval = 1;
+  const unsigned int default_interval = 30;
 
   pid_t pid = -1;
   bool got_pid = false;

--- a/package/tests/testCPU.py
+++ b/package/tests/testCPU.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import unittest
 
-def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, slack=0.75, invoke=False):
+def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, slack=0.75, interval=1, invoke=False):
     '''Wrap the class definition in a function to allow arguments to be passed'''
     class configurableProcessMonitor(unittest.TestCase):
         def test_runTestWithParams(self):
@@ -22,8 +22,9 @@ def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, sla
             if child_fraction != 1.0:
                 burn_cmd.extend(['--child-fraction', str(child_fraction)])
 
+            prmon_cmd = ['../prmon', '--interval', str(interval)]
             if invoke:
-                prmon_cmd = ['../prmon', '--']
+                prmon_cmd.append('--')
                 prmon_cmd.extend(burn_cmd)
                 prmon_p = subprocess.Popen(prmon_cmd, shell = False)
 
@@ -31,7 +32,7 @@ def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, sla
             else:
                 burn_p = subprocess.Popen(burn_cmd, shell = False)
     
-                prmon_cmd = ['../prmon', '--pid', str(burn_p.pid)]
+                prmon_cmd.extend(['--pid', str(burn_p.pid)])
                 prmon_p = subprocess.Popen(prmon_cmd, shell = False)
     
                 burn_rc = burn_p.wait()
@@ -66,12 +67,13 @@ if __name__ == '__main__':
     parser.add_argument('--child-fraction', type=float, default=1.0)
     parser.add_argument('--time', type=float, default=10)
     parser.add_argument('--slack', type=float, default=0.75)
+    parser.add_argument('--interval', type=int, default=1)
     parser.add_argument('--invoke', dest='invoke', action='store_true', default=False)
 
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments
     sys.argv=sys.argv[:1]
     
-    cpm = setupConfigurableTest(args.threads,args.procs,args.child_fraction,args.time,args.slack,args.invoke)
+    cpm = setupConfigurableTest(args.threads,args.procs,args.child_fraction,args.time,args.slack,args.interval,args.invoke)
     
     unittest.main()

--- a/package/tests/testIO.py
+++ b/package/tests/testIO.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import unittest
 
-def setupConfigurableTest(io=10, threads=1, procs=1, usleep=10, pause=1, slack=0.95):
+def setupConfigurableTest(io=10, threads=1, procs=1, usleep=10, pause=1, slack=0.95, interval=1):
     '''Wrap the class definition in a function to allow arguments to be passed'''
     class configurableProcessMonitor(unittest.TestCase):
         def test_runTestWithParams(self):
@@ -21,7 +21,7 @@ def setupConfigurableTest(io=10, threads=1, procs=1, usleep=10, pause=1, slack=0
             burn_cmd.extend(['--pause', str(pause)])
             burn_p = subprocess.Popen(burn_cmd, shell = False)
     
-            prmon_cmd = ['../prmon', '--pid', str(burn_p.pid)]
+            prmon_cmd = ['../prmon', '--interval', str(interval), '--pid', str(burn_p.pid)]
             prmon_p = subprocess.Popen(prmon_cmd, shell = False)
     
             burn_rc = burn_p.wait()
@@ -50,10 +50,11 @@ if __name__ == '__main__':
     parser.add_argument('--usleep', type=int, default=10)
     parser.add_argument('--pause', type=float, default=1)
     parser.add_argument('--slack', type=float, default=0.95)
+    parser.add_argument('--interval', type=int, default=1)
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments
     sys.argv=sys.argv[:1]
     
-    cpm = setupConfigurableTest(args.io, args.threads, args.procs, args.usleep, args.pause, args.slack)
+    cpm = setupConfigurableTest(args.io, args.threads, args.procs, args.usleep, args.pause, args.slack, args.interval)
     
     unittest.main()

--- a/package/tests/testMEM.py
+++ b/package/tests/testMEM.py
@@ -11,7 +11,7 @@ import sys
 import unittest
 
 
-def setupConfigurableTest(procs=4, malloc_mb = 100, write_fraction=0.5, sleep=10, slack=0.9):
+def setupConfigurableTest(procs=4, malloc_mb = 100, write_fraction=0.5, sleep=10, slack=0.9, interval=1):
     '''Wrap the class definition in a function to allow arguments to be passed'''
     class configurableProcessMonitor(unittest.TestCase):
         def checkMemoryLimits(self, name, value, expected, slack):
@@ -27,7 +27,7 @@ def setupConfigurableTest(procs=4, malloc_mb = 100, write_fraction=0.5, sleep=10
             if procs != 1:
                 burn_cmd.extend(['--procs', str(procs)])
 
-            prmon_cmd = ['../prmon', '--']
+            prmon_cmd = ['../prmon', '--interval', str(interval), '--']
             prmon_cmd.extend(burn_cmd)
             prmon_p = subprocess.Popen(prmon_cmd, shell = False)
 
@@ -59,11 +59,12 @@ if __name__ == '__main__':
     parser.add_argument('--writef', type=float, default=0.5)
     parser.add_argument('--sleep', type=int, default=10)
     parser.add_argument('--slack', type=float, default=0.9)
+    parser.add_argument('--interval', type=int, default=1)  
 
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments
     sys.argv=sys.argv[:1]
     
-    cpm = setupConfigurableTest(args.procs,args.malloc,args.writef,args.sleep,args.slack)
+    cpm = setupConfigurableTest(args.procs,args.malloc,args.writef,args.sleep,args.slack,args.interval)
     
     unittest.main()

--- a/package/tests/testNET.py
+++ b/package/tests/testNET.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import unittest
 
-def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slack=0.95):
+def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slack=0.95, interval=1):
     '''Wrap the class definition in a function to allow arguments to be passed'''
     class configurableProcessMonitor(unittest.TestCase):
         def setUp(self):
@@ -35,7 +35,7 @@ def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slac
             if blocks:
                 burn_cmd.extend(['--blocks', str(blocks)])
             burn_p = subprocess.Popen(burn_cmd, shell=False)    
-            prmon_cmd = ['../prmon', '--pid', str(burn_p.pid)]
+            prmon_cmd = ['../prmon', '--interval', str(interval), '--pid', str(burn_p.pid)]
             prmon_p = subprocess.Popen(prmon_cmd, shell = False)
     
             burn_rc = burn_p.wait()
@@ -63,10 +63,11 @@ if __name__ == '__main__':
     parser.add_argument('--sleep', type=float)
     parser.add_argument('--pause', type=float)
     parser.add_argument('--slack', type=float, default=0.95)
+    parser.add_argument('--interval', type=int, default=1)
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments
     sys.argv=sys.argv[:1]
     
-    cpm = setupConfigurableTest(args.blocks, args.requests, args.sleep, args.pause, args.slack)
+    cpm = setupConfigurableTest(args.blocks, args.requests, args.sleep, args.pause, args.slack, args.interval)
     
     unittest.main()


### PR DESCRIPTION
Default in prmon changed to 30s, as discussed in #49.

Tests are updated to implement a '--interval' option, set by default to 1s, so the they monitor short processes properly.

Unit tests checked on C7 (Docker), U16 (Docker), SLC6 (lxplus) and C7 (lxplus).