### PR TITLE
Remove clock_ticks const statics

### DIFF
--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -38,7 +38,7 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
     }
     stat_entries.clear();
   }
-  for (auto& stat : cpu_stats) stat.second *= prmon::inv_clock_ticks;
+  for (auto& stat : cpu_stats) stat.second /= sysconf(_SC_CLK_TCK);
 }
 
 // Return the summed counters

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -56,7 +56,7 @@ std::map<std::string, unsigned long long> const iomon::get_json_average_stats(
   std::map<std::string, unsigned long long> json_average_stats{};
   for (const auto& io_param : io_stats) {
     json_average_stats[io_param.first] =
-        (io_param.second * prmon::clock_ticks) / elapsed_clock_ticks;
+        (io_param.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -100,7 +100,7 @@ std::map<std::string, unsigned long long> const netmon::get_json_total_stats() {
 std::map<std::string, unsigned long long> const netmon::get_json_average_stats(unsigned long long elapsed_clock_ticks) {
   std::map<std::string, unsigned long long> json_average_stats = get_text_stats();
   for (auto& stat : json_average_stats) {
-    stat.second = (stat.second * prmon::clock_ticks) / elapsed_clock_ticks;
+    stat.second = (stat.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -7,10 +7,6 @@
 #include <unistd.h>
 
 namespace prmon {
-  // For conversion from second <-> clock ticks
-  const static unsigned long clock_ticks = sysconf(_SC_CLK_TCK);
-  const static float inv_clock_ticks = 1. / sysconf(_SC_CLK_TCK);
-
   // These constants define where in the stat entry from proc
   // we find the parameters of interest
   const size_t utime_pos = 13;

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -61,8 +61,8 @@ void wallmon::update_stats(const std::vector<pid_t>& pids) {
     std::clog << "Error while reading /proc/uptime" << std::endl;
     return;
   }
-  current_clock_t = uptime_sec * prmon::clock_ticks - start_time_clock_t;
-  walltime_stats["wtime"] = current_clock_t * prmon::inv_clock_ticks;
+  current_clock_t = uptime_sec * sysconf(_SC_CLK_TCK) - start_time_clock_t;
+  walltime_stats["wtime"] = current_clock_t / sysconf(_SC_CLK_TCK);
 }
 
 unsigned long long const wallmon::get_wallclock_clock_t() {


### PR DESCRIPTION
Some gcc compiler versions claim these are unused variables and throw a compiler warning, that bombs the build with the -Werror option being set.

This fixes #60.