### PR TITLE
Add a CMake build option to generate a static binary and support profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,16 +20,37 @@ include(GNUInstallDirs)
 if(NOT CMAKE_CONFIGURATION_TYPES)
   if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo Static"
       FORCE
       )
   else()
     set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo Static"
       FORCE
       )
   endif()
 endif()
+
+# - Define the static build type as this is very useful for a utility like prmon
+SET( CMAKE_CXX_FLAGS_STATIC "-O2" CACHE STRING
+    "Flags used by the C++ compiler during static builds."
+    FORCE )
+SET( CMAKE_C_FLAGS_STATIC "-O2" CACHE STRING
+    "Flags used by the C compiler during static builds."
+    FORCE )
+SET( CMAKE_EXE_LINKER_FLAGS_STATIC
+    "-Wl,--warn-unresolved-symbols,--warn-once -static" CACHE STRING
+    "Flags used for linking binaries during static builds."
+    FORCE )
+SET( CMAKE_SHARED_LINKER_FLAGS_STATIC
+    "-Wl,--warn-unresolved-symbols,--warn-once" CACHE STRING
+    "Flags used by the shared libraries linker during static builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_STATUC
+    CMAKE_C_FLAGS_STATIC
+    CMAKE_EXE_LINKER_FLAGS_STATIC
+    CMAKE_SHARED_LINKER_FLAGS_STATIC )
 
 # - Define the C++ Standard to use (Simplest Possible)
 # This will add any compiler flags needed to compile against the required standard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,44 +13,19 @@ include(GNUInstallDirs)
 # - Define a default build type when using a single-mode tool like make/ninja
 # If you're using a build tool that supports multiple modes (Visual Studio,
 # Xcode), this setting has no effect.
-# HSF recommend RelWithDebInfo (optimized with debugging symbols) as this is
-# generally the mode used by system packaging (rpm, deb, spack, macports).
-# However, it can be overriden by passing ``-DCMAKE_BUILD_TYPE=<type>`` when
-# invoking CMake
 if(NOT CMAKE_CONFIGURATION_TYPES)
   if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo Static"
+    set(CMAKE_BUILD_TYPE Release
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
       FORCE
       )
   else()
     set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo Static"
+      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
       FORCE
       )
   endif()
 endif()
-
-# - Define the static build type as this is very useful for a utility like prmon
-SET( CMAKE_CXX_FLAGS_STATIC "-O2" CACHE STRING
-    "Flags used by the C++ compiler during static builds."
-    FORCE )
-SET( CMAKE_C_FLAGS_STATIC "-O2" CACHE STRING
-    "Flags used by the C compiler during static builds."
-    FORCE )
-SET( CMAKE_EXE_LINKER_FLAGS_STATIC
-    "-Wl,--warn-unresolved-symbols,--warn-once -static" CACHE STRING
-    "Flags used for linking binaries during static builds."
-    FORCE )
-SET( CMAKE_SHARED_LINKER_FLAGS_STATIC
-    "-Wl,--warn-unresolved-symbols,--warn-once" CACHE STRING
-    "Flags used by the shared libraries linker during static builds."
-    FORCE )
-MARK_AS_ADVANCED(
-    CMAKE_CXX_FLAGS_STATUC
-    CMAKE_C_FLAGS_STATIC
-    CMAKE_EXE_LINKER_FLAGS_STATIC
-    CMAKE_SHARED_LINKER_FLAGS_STATIC )
 
 # - Define the C++ Standard to use (Simplest Possible)
 # This will add any compiler flags needed to compile against the required standard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Set the compiler to be more picky
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -Werror")
 
+# Add package utilities to CMake path
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
+
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,22 +10,39 @@ project(prmon VERSION 0.1.0)
 # - Use GNU-style hierarchy for installing build products
 include(GNUInstallDirs)
 
-# - Define a default build type when using a single-mode tool like make/ninja
-# If you're using a build tool that supports multiple modes (Visual Studio,
-# Xcode), this setting has no effect.
-if(NOT CMAKE_CONFIGURATION_TYPES)
-  if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
-      FORCE
-      )
+# Add some build option variables, for static builds and profiling
+if(NOT BUILD_STATIC)
+  set(BUILD_STATIC OFF)
+endif()
+set(BUILD_STATIC "${BUILD_STATIC}"
+  CACHE BOOL "Build a static version of the prmon binary" FORCE)
+
+if(NOT PROFILE_GPROF)
+  set(PROFILE_GPROF OFF)
+endif()
+set(PROFILE_GPROF "${PROFILE_GPROF}"
+  CACHE BOOL "Build with the GNU profile option set" FORCE)
+
+if(NOT PROFILE_GPERFTOOLS)
+  set(PROFILE_GPERFTOOLS OFF)
+endif()
+set(PROFILE_GPERFTOOLS "${PROFILE_GPERFTOOLS}"
+  CACHE BOOL "Build with the GPerfTools profiler library" FORCE)
+
+
+# Define a default build type when using a single-mode tool like make/ninja
+# We make this default to Release, unless profiling is enabled, in which
+# case do RelWithDebInfo (bcause you need the debug symbols)
+if(NOT CMAKE_BUILD_TYPE)
+  if(PROFILE_GPROF OR PROFILE_GPERFTOOLS)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
   else()
-    set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
-      CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
-      FORCE
-      )
+    set(CMAKE_BUILD_TYPE Release)
   endif()
 endif()
+set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
+  CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo" FORCE)
+
 
 # - Define the C++ Standard to use (Simplest Possible)
 # This will add any compiler flags needed to compile against the required standard

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Pull requests are very welcome.
 To build prmon with profiling set one of the CMake variables
 `PROFILE_GPROF` or `PROFILE_GPERFTOOLS` to `ON`. This enables
 GNU prof profiling or gperftools profiling, respectively.
+If your gperftools are in a non-standard place, pass a hint
+to CMake using `Gperftools_ROOT_DIR`.
 
 
 # Copyright

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ The option `-DCMAKE_BUILD_TYPE` can switch between all of the standard
 build types. The default is `Release`; use `RelWithDebInfo` if you want
 debug symbols.
 
-To build a statically linked version of `prmon` use
-`-DBUILD_STATIC=1`.
+To build a statically linked version of `prmon` set the `BUILD_STATIC`
+CMake variable to `ON` (e.g., adding `-DBUILD_STATIC=ON` to the 
+command line).
 
 Note that in a build environment with CVMFS available the C++ compiler
 and CMake can be taken by setting up a recent LCG release.
@@ -113,8 +114,9 @@ Pull requests are very welcome.
 
 ### Profiling
 
-If you want to profile `prmon` see the notes in 
-the `package/CMakeLists.txt` file.
+To build prmon with profiling set one of the CMake variables
+`PROFILE_GPROF` or `PROFILE_GPERFTOOLS` to `ON`. This enables
+GNU prof profiling or gperftools profiling, respectively.
 
 
 # Copyright

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ If your installation of RapidJSON is in a non-standard location then
 setting `RapidJSON_DIR` may be required as a hint to CMake.
 
 The option `-DCMAKE_BUILD_TYPE` can switch between all of the standard
-build types; one useful non-standard option is supported, 
-viz. `-DCMAKE_BUILD_TYPE=Static` which builds `prmon` as a static binary.
+build types. The default is `Release`; use `RelWithDebInfo` if you want
+debug symbols.
+
+To build a statically linked version of `prmon` use
+`-DBUILD_STATIC=1`.
 
 Note that in a build environment with CVMFS available the C++ compiler
 and CMake can be taken by setting up a recent LCG release.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Building should be as simple as
 If your installation of RapidJSON is in a non-standard location then
 setting `RapidJSON_DIR` may be required as a hint to CMake.
 
+The option `-DCMAKE_BUILD_TYPE` can switch between all of the standard
+build types; one useful non-standard option is supported, 
+viz. `-DCMAKE_BUILD_TYPE=Static` which builds `prmon` as a static binary.
+
 Note that in a build environment with CVMFS available the C++ compiler
 and CMake can be taken by setting up a recent LCG release.
 

--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tries to find Gperftools.
+#
+# Usage of this module as follows:
+#
+#     find_package(Gperftools)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  Gperftools_ROOT_DIR  Set this variable to the root installation of
+#                       Gperftools if the module has problems finding
+#                       the proper installation path.
+#
+# Variables defined by this module:
+#
+#  GPERFTOOLS_FOUND              System has Gperftools libs/headers
+#  GPERFTOOLS_LIBRARIES          The Gperftools libraries (tcmalloc & profiler)
+#  GPERFTOOLS_INCLUDE_DIR        The location of Gperftools headers
+
+find_library(GPERFTOOLS_TCMALLOC
+  NAMES tcmalloc
+  HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_library(GPERFTOOLS_PROFILER
+  NAMES profiler
+  HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_library(GPERFTOOLS_TCMALLOC_AND_PROFILER
+  NAMES tcmalloc_and_profiler
+  HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_path(GPERFTOOLS_INCLUDE_DIR
+  NAMES gperftools/heap-profiler.h
+  HINTS ${Gperftools_ROOT_DIR}/include)
+
+set(GPERFTOOLS_LIBRARIES ${GPERFTOOLS_TCMALLOC_AND_PROFILER})
+set(GPERFTOOLS_PROFILE_LIBRARY ${GPERFTOOLS_PROFILER})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Gperftools
+  DEFAULT_MSG
+  GPERFTOOLS_LIBRARIES
+  GPERFTOOLS_PROFILE_LIBRARY
+  GPERFTOOLS_INCLUDE_DIR)
+
+mark_as_advanced(
+  Gperftools_ROOT_DIR
+  GPERFTOOLS_TCMALLOC
+  GPERFTOOLS_PROFILER
+  GPERFTOOLS_TCMALLOC_AND_PROFILER
+  GPERFTOOLS_LIBRARIES
+  GPERFTOOLS_PROFILE_LIBRARY
+  GPERFTOOLS_INCLUDE_DIR)
+

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,15 +1,6 @@
 find_package(RapidJSON REQUIRED)
 find_package(Threads REQUIRED)
 
-## Profiling
-# If you wish to compile prmon with profiling then just 
-# uncomment the line below to use gprof:
-#
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
-#
-# If you want to use gperftools then add "profiler" to
-# the prmon target_link_libraries command instead
-
 add_executable(prmon src/prmon.cpp
 					 src/pidutils.cpp
 					 src/netmon.cpp 
@@ -20,9 +11,19 @@ add_executable(prmon src/prmon.cpp
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 
+# Set flags based on more unusual build flags
 if(BUILD_STATIC)
   set_target_properties(prmon PROPERTIES LINK_FLAGS "-static")
 endif(BUILD_STATIC)
+
+if(PROFILE_GPROF)
+  set_target_properties(prmon PROPERTIES COMPILE_FLAGS "-pg")
+  set_target_properties(prmon PROPERTIES LINK_FLAGS "-pg")
+endif(PROFILE_GPROF)
+
+if(PROFILE_GPERFTOOLS)
+  set_target_properties(prmon PROPERTIES LINK_LIBRARIES "profiler")
+endif(PROFILE_GPERFTOOLS)
 
 # - Install the example library into the install time library directory
 # The EXPORT name is used so that we can "export" the target for

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -20,7 +20,9 @@ add_executable(prmon src/prmon.cpp
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+if(BUILD_STATIC)
+  set_target_properties(prmon PROPERTIES LINK_FLAGS "-static")
+endif(BUILD_STATIC)
 
 # - Install the example library into the install time library directory
 # The EXPORT name is used so that we can "export" the target for

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(prmon src/prmon.cpp
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
 target_link_libraries(prmon Threads::Threads)
 
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+
 # - Install the example library into the install time library directory
 # The EXPORT name is used so that we can "export" the target for
 # use by client projects

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,5 +1,4 @@
 find_package(RapidJSON REQUIRED)
-find_package(Threads REQUIRED)
 
 add_executable(prmon src/prmon.cpp
 					 src/pidutils.cpp
@@ -9,7 +8,6 @@ add_executable(prmon src/prmon.cpp
 					 src/wallmon.cpp
 					 src/memmon.cpp)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})
-target_link_libraries(prmon Threads::Threads)
 
 # Set flags based on more unusual build flags
 if(BUILD_STATIC)

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -20,7 +20,8 @@ if(PROFILE_GPROF)
 endif(PROFILE_GPROF)
 
 if(PROFILE_GPERFTOOLS)
-  set_target_properties(prmon PROPERTIES LINK_LIBRARIES "profiler")
+  find_package(Gperftools REQUIRED)
+  set_target_properties(prmon PROPERTIES LINK_LIBRARIES ${GPERFTOOLS_PROFILE_LIBRARY})
 endif(PROFILE_GPERFTOOLS)
 
 # - Install the example library into the install time library directory

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -35,14 +35,10 @@
 
 using namespace rapidjson;
 
-std::condition_variable cv;
-std::mutex cv_m;
 bool sigusr1 = false;
 
 void SignalCallbackHandler(int /*signal*/) {
-  std::lock_guard<std::mutex> l(cv_m);
   sigusr1 = true;
-  cv.notify_one();
 }
 
 void SignalChildHandler(int /*signal*/) {
@@ -206,8 +202,7 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
                   << std::endl;
       }
     }
-    std::unique_lock<std::mutex> lock(cv_m);
-    cv.wait_for(lock, std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
   }
   file.close();
 


### PR DESCRIPTION
For a utility like prmon having a statically build binary is a very useful thing to then be able to ship it around between machines and OSs, so add the correct compiler and linker options to do that.

This was suggested by @bencouturier - thanks!
