### PR TITLE
Minor clean up of variables

### DIFF
--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -7,16 +7,10 @@
 #include <iostream>
 #include <sstream>
 
-const static std::vector<std::string> default_io_params{
-    "rchar", "wchar", "read_bytes", "write_bytes"};
-
-const static unsigned int fname_size{64};
-const static unsigned int line_buf_size{256};
-
 // Constructor; uses RAII pattern to be valid
 // after construction
 iomon::iomon() : io_stats{} {
-  for (const auto& io_param : default_io_params) io_stats[io_param] = 0;
+  for (const auto& io_param : prmon::default_io_params) io_stats[io_param] = 0;
 }
 
 void iomon::update_stats(const std::vector<pid_t>& pids) {

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -22,6 +22,8 @@ namespace prmon {
       "rx_bytes", "rx_packets", "tx_bytes", "tx_packets"};
   const static std::vector<std::string> default_wall_params{"wtime"};
   const static std::vector<std::string> default_memory_params{"vmem", "pss", "rss", "swap"};
+  const static std::vector<std::string> default_io_params{
+      "rchar", "wchar", "read_bytes", "write_bytes"};
 }
 
 #endif  // PRMON_UTILS_H


### PR DESCRIPTION
Remove the unused static const variables from iomon (legacy of old io reader) and move the definition of the default parameter set to utils.h for consistency.

Interestingly these variables were caught by Apple Clang.