### PR TITLE
CMake update for plotting script

### DIFF
--- a/package/scripts/CMakeLists.txt
+++ b/package/scripts/CMakeLists.txt
@@ -1,3 +1,2 @@
 # Install the scripts under bin in the install area
-set(SCRIPTS_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-install(PROGRAMS prmon_plot.py DESTINATION ${SCRIPTS_INSTALL_PATH})
+install(PROGRAMS prmon_plot.py DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Installing the `prmon_plot.py` directly under `${CMAKE_INSTALL_BINDIR}` seems to take care of putting it in the package when `make package` is invoked. Cross-check is most welcome.