### PR TITLE
Static build package name

### DIFF
--- a/cmake/prmonCPack.cmake
+++ b/cmake/prmonCPack.cmake
@@ -53,34 +53,9 @@ function(hsf_get_platform _output_var)
   # Strip version to MAJORMINOR (?)
   string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_COMPILER_VERSION ${HSF_COMPILER_VERSION})
 
-  # - Determine OS info
-  # NOTE: This derives *HOST* OS info, *NOT* *TARGET* OS
-  #       Needs more thought for cross-compile cases, though likely reduces
-  #       to check on CMAKE_CROSS_COMPILING and subsequent use of the needed
-  #       variables as defined in the toolchain file
-  if(APPLE)
-    set(HSF_OS_ID "macos")
-    execute_process(COMMAND sw_vers -productVersion
-      COMMAND cut -d . -f 1-2
-      OUTPUT_VARIABLE HSF_OS_VERSION
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
-    string(REPLACE "." "" HSF_OS_VERSION ${HSF_OS_VERSION})
-  elseif(WIN32)
-    # Should be able to determine gross Windows version from CMAKE_SYSTEM_VERSION
-    set(HSF_OS_ID "win")
-    if(CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.1")
-      set(HSF_OS_VERSION "7")
-    elseif(CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.2")
-      set(HSF_OS_VERSION "8")
-    elseif(CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.3")
-      set(HSF_OS_VERSION "8")
-    elseif(CMAKE_SYSTEM_VERSION VERSION_EQUAL "10.0")
-      set(HSF_OS_VERSION "10")
-    else()
-      set(HSF_OS_VERSION "unknown")
-    endif()
-  elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  # - Determine OS info - only Linux is really supported
+  #   as we only function with /proc 
+  if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     if(BUILD_STATIC)
       # For a static build the linux distribution
       # doesn't really matter

--- a/cmake/prmonCPack.cmake
+++ b/cmake/prmonCPack.cmake
@@ -81,49 +81,56 @@ function(hsf_get_platform _output_var)
       set(HSF_OS_VERSION "unknown")
     endif()
   elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    # Use /etc/os-release if it's present
-    if(EXISTS "/etc/os-release")
-      # - Parse based on spec from freedesktop
-      # http://www.freedesktop.org/software/systemd/man/os-release.html
-      # - ID
-      file(STRINGS "/etc/os-release" HSF_OS_ID REGEX "^ID=.*$")
-      if(HSF_OS_ID)
-        string(REGEX REPLACE "ID=|\"" "" HSF_OS_ID ${HSF_OS_ID})
-      else()
-        set(HSF_OS_ID "unknown")
-      endif()
-      # - VERSION_ID
-      file(STRINGS "/etc/os-release" HSF_OS_VERSION REGEX "^VERSION_ID=.*$")
-      if(HSF_OS_VERSION)
-        string(REGEX REPLACE "VERSION_ID=|\"" "" HSF_OS_VERSION ${HSF_OS_VERSION})
-        string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${HSF_OS_VERSION})
-      else()
-        set(HSF_OS_VERSION "0")
-      endif()
+    if(BUILD_STATIC)
+      # For a static build the linux distribution
+      # doesn't really matter
+      set(HSF_OS_ID "static")
+      set(HSF_OS_VERSION "")
     else()
-      # Workaround for older systems
-      # 1. Might be lucky and have lsb_release
-      find_program(prmon_LSB_RELEASE_EXECUTABLE lsb_release
-        DOC "Path to lsb_release program"
-        )
-      mark_as_advanced(prmon_LSB_RELEASE_EXECUTABLE)
-      if(prmon_LSB_RELEASE_EXECUTABLE)
+    # Use /etc/os-release if it's present
+      if(EXISTS "/etc/os-release")
+        # - Parse based on spec from freedesktop
+        # http://www.freedesktop.org/software/systemd/man/os-release.html
         # - ID
-        execute_process(COMMAND ${prmon_LSB_RELEASE_EXECUTABLE} -is
-          OUTPUT_VARIABLE HSF_OS_ID
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          )
-        string(TOLOWER ${HSF_OS_ID} HSF_OS_ID)
-        # - Version
-        execute_process(COMMAND ${prmon_LSB_RELEASE_EXECUTABLE} -ir
-          OUTPUT_VARIABLE HSF_OS_VERSION
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          )
-        string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${HSF_OS_VERSION})
+        file(STRINGS "/etc/os-release" HSF_OS_ID REGEX "^ID=.*$")
+        if(HSF_OS_ID)
+          string(REGEX REPLACE "ID=|\"" "" HSF_OS_ID ${HSF_OS_ID})
+        else()
+          set(HSF_OS_ID "unknown")
+        endif()
+        # - VERSION_ID
+        file(STRINGS "/etc/os-release" HSF_OS_VERSION REGEX "^VERSION_ID=.*$")
+        if(HSF_OS_VERSION)
+          string(REGEX REPLACE "VERSION_ID=|\"" "" HSF_OS_VERSION ${HSF_OS_VERSION})
+          string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${HSF_OS_VERSION})
+        else()
+          set(HSF_OS_VERSION "0")
+        endif()
       else()
-        # 2. Only mark in general terms, or have to check for possible /etc/VENDOR-release files
-        set(HSF_OS_ID "linux")
-        string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${CMAKE_SYSTEM_VERSION})
+        # Workaround for older systems
+        # 1. Might be lucky and have lsb_release
+        find_program(prmon_LSB_RELEASE_EXECUTABLE lsb_release
+          DOC "Path to lsb_release program"
+          )
+        mark_as_advanced(prmon_LSB_RELEASE_EXECUTABLE)
+        if(prmon_LSB_RELEASE_EXECUTABLE)
+          # - ID
+          execute_process(COMMAND ${prmon_LSB_RELEASE_EXECUTABLE} -is
+            OUTPUT_VARIABLE HSF_OS_ID
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+          string(TOLOWER ${HSF_OS_ID} HSF_OS_ID)
+          # - Version
+          execute_process(COMMAND ${prmon_LSB_RELEASE_EXECUTABLE} -ir
+            OUTPUT_VARIABLE HSF_OS_VERSION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+          string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${HSF_OS_VERSION})
+        else()
+          # 2. Only mark in general terms, or have to check for possible /etc/VENDOR-release files
+          set(HSF_OS_ID "linux")
+          string(REGEX REPLACE "([a-z0-9]+)(\.|-|_)([a-z0-9]+).*" "\\1\\3" HSF_OS_VERSION ${CMAKE_SYSTEM_VERSION})
+        endif()
       endif()
     endif()
   else()


### PR DESCRIPTION
I tweaked the CPack build setup a bit

- When a static binary build is done, ignore the distro version and produce a tarball with "static" in the name, e.g., `prmon_1.0.1_x86_64-static-gnu72-opt.tar.gz`

- Remove the Windows and OS X packaging setups as prmon does not support these platforms

(This was the patch that was used to create the tarball for https://github.com/HSF/prmon/releases/tag/v1.0.1)