### PR TITLE
WIP: Add Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+language: c++
+
+services:
+  - docker
+  
+before_install:
+  - docker pull graemeastewart/u16-dev
+ 
+install:
+  - /bin/true
+
+script:
+  - SRC=`pwd`
+  - mkdir ../build
+  - cd ../build
+  - cmake -DCMAKE_CXX_COMPILER=/usr/bin/g++-7 -DCMAKE_C_COMPILER=/usr/bin/gcc-7 $SRC
+  - make -j
+  - make test


### PR DESCRIPTION
Builds prmon on Ubuntu16 (container with pre-installed RapidJSON)
and runs the standard test suite.