### PR TITLE
Updating Travis configuration and README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 sudo: required
 
+# Add only master and stable branches
+branches:
+  only:
+    - master
+    - stable 
+
+# Notify on failure
+notifications:
+  email: on_failure
+
 # Test across multiple containers 
 env:
   - DIMAGE=graemeastewart/u16-dev

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status][build-img]][build-link]  [![License][license-img]][license-url]
 
 [build-img]: https://travis-ci.com/hsf/prmon.svg?branch=master
-[build-link]: https://travis-ci.com/hsf/prmon
+[build-link]: https://travis-ci.com/HSF/prmon
 [license-img]: https://img.shields.io/github/license/hsf/prmon.svg 
 [license-url]: https://github.com/hsf/prmon/blob/master/LICENSE
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Process Monitor (prmon)
 
+[![Build Status][build-img]][build-link]  [![License][license-img]][license-url]
+
+[build-img]: https://travis-ci.com/hsf/prmon.svg?branch=master
+[build-link]: https://travis-ci.com/hsf/prmon
+[license-img]: https://img.shields.io/github/license/hsf/prmon.svg 
+[license-url]: https://github.com/hsf/prmon/blob/master/LICENSE
+
 The PRocess MONitor is a small stand alone program that can monitor
 the resource consumption of a process and its children. This is 
 useful in the context of the WLCG/HSF working group to evaluate


### PR DESCRIPTION
I simply turned on the push builds on travis, updated the yaml configuration such that we only build master/stable branches, and added some information to the README regarding the build status and the license.  I believe when we merge this to the master branch it should invoke a build whose result should then appear on the front page.

Next I'll take a look at possibility of adding coverity stuff.