### PR TITLE
Adding the number of processes and threads to address #78

### DIFF
--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(prmon src/prmon.cpp
 					 src/netmon.cpp 
 					 src/iomon.cpp 
 					 src/cpumon.cpp 
+					 src/countmon.cpp 
 					 src/wallmon.cpp
 					 src/memmon.cpp)
 target_include_directories(prmon PRIVATE ${RapidJSON_INCLUDE_DIR})

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) CERN, 2018
+
+#include "countmon.h"
+#include "utils.h"
+
+#include <string.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+// Constructor; uses RAII pattern to be valid
+// after construction
+countmon::countmon() : count_params{prmon::default_count_params},  
+  count_stats{}, count_average_stats{}, count_total_stats{}, iterations{0L} {
+  for (const auto& count_param : count_params) { 
+    count_stats[count_param] = 0;
+    count_peak_stats[count_param] = 0;
+    count_average_stats[count_param] = 0;
+    count_total_stats[count_param] = 0;
+  }
+}
+
+void countmon::update_stats(const std::vector<pid_t>& pids) {
+  for (auto& stat : count_stats) stat.second = 0;
+
+  std::vector<std::string> stat_entries{};
+  stat_entries.reserve(prmon::stat_count_read_limit + 1);
+  std::string tmp_str{};
+  for (const auto pid : pids) {
+    std::stringstream stat_fname{};
+    stat_fname << "/proc/" << pid << "/stat" << std::ends;
+    std::ifstream proc_stat{stat_fname.str()};
+    while (proc_stat && stat_entries.size() < prmon::stat_count_read_limit + 1) {
+      proc_stat >> tmp_str;
+      if (proc_stat) stat_entries.push_back(tmp_str);
+    }
+    if (stat_entries.size() > prmon::stat_count_read_limit) {
+      count_stats["nprocs"]   += 1L; 
+      count_stats["nthreads"] += std::stol(stat_entries[prmon::num_threads]) - 1L; 
+    }
+    stat_entries.clear();
+  }
+
+  // Update the statistics with the new snapshot values
+  ++iterations;
+  for(const auto& count_param : count_params) {
+    if(count_stats[count_param] > count_peak_stats[count_param])
+      count_peak_stats[count_param] = count_stats[count_param];
+    count_total_stats[count_param] += count_stats[count_param];
+    count_average_stats[count_param] = count_total_stats[count_param] / iterations; 
+  }
+}
+
+// Return the counters
+std::map<std::string, unsigned long long> const countmon::get_text_stats() {
+  return count_stats;
+}
+
+// For JSON return the peaks
+std::map<std::string, unsigned long long> const countmon::get_json_total_stats() {
+  return count_peak_stats;
+}
+
+// An the averages 
+std::map<std::string, unsigned long long> const countmon::get_json_average_stats(
+    unsigned long long elapsed_clock_ticks) {
+  return count_average_stats;
+}

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -1,0 +1,42 @@
+// Copyright (C) CERN, 2018
+//
+// Process and thread number monitoring class
+//
+
+#ifndef PRMON_COUNTMON_H
+#define PRMON_COUNTMON_H 1
+
+#include <string>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "Imonitor.h"
+
+class countmon final : public Imonitor {
+ private:
+  // Which network count paramters to measure and output key names
+  std::vector<std::string> count_params;
+
+  // Container for total stats
+  std::map<std::string, unsigned long long> count_stats;
+  std::map<std::string, unsigned long long> count_peak_stats;
+  std::map<std::string, unsigned long long> count_average_stats;
+  std::map<std::string, unsigned long long> count_total_stats;
+
+  // Counter for number of iterations
+  unsigned long iterations;
+
+ public:
+  countmon();
+
+  void update_stats(const std::vector<pid_t>& pids);
+
+  // These are the stat getter methods which retrieve current statistics
+  std::map<std::string, unsigned long long> const get_text_stats();
+  std::map<std::string, unsigned long long> const get_json_total_stats();
+  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+
+};
+
+#endif  // PRMON_COUNTMON_H

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -32,6 +32,7 @@
 #include "pidutils.h"
 #include "prmon.h"
 #include "wallmon.h"
+#include "countmon.h"
 
 using namespace rapidjson;
 
@@ -71,6 +72,10 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
 
   // This is the vector of all monitoring components
   std::vector<Imonitor*> monitors{};
+
+  // Number of processes and threads monitoring
+  countmon count_monitor{};
+  monitors.push_back(&count_monitor);
 
   // Wall clock monitoring
   wallmon wall_monitor{};

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -14,6 +14,8 @@ namespace prmon {
   const size_t cutime_pos = 15;
   const size_t cstime_pos = 16;
   const size_t stat_cpu_read_limit = 16;
+  const size_t num_threads = 19;
+  const size_t stat_count_read_limit = 19;
   const size_t uptime_pos = 21;
 
   // Default parameter lists for monitor classes
@@ -24,6 +26,7 @@ namespace prmon {
   const static std::vector<std::string> default_memory_params{"vmem", "pss", "rss", "swap"};
   const static std::vector<std::string> default_io_params{
       "rchar", "wchar", "read_bytes", "write_bytes"};
+  const static std::vector<std::string> default_count_params{"nprocs", "nthreads"};
 }
 
 #endif  // PRMON_UTILS_H

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ script_install(SCRIPT testNET.py)
 script_install(SCRIPT testMEM.py)
 script_install(SCRIPT netBurner.py)
 script_install(SCRIPT httpBlock.py DESTINATION cgi-bin)
+script_install(SCRIPT testCOUNT.py)
 
 # CPU Tests
 add_test(NAME testCPUsingle COMMAND testCPU.py --threads 1 --procs 1) 
@@ -55,3 +56,6 @@ add_test(NAME basicNET COMMAND python testNET.py)
 # Memory Tests
 add_test(NAME singleMem COMMAND python testMEM.py --procs 1)
 add_test(NAME childMem COMMAND python testMEM.py --procs 4)
+
+# Process and thread counting Tests
+add_test(NAME basicCOUNT COMMAND python testCOUNT.py --procs 2 --threads 2)

--- a/package/tests/testCOUNT.py
+++ b/package/tests/testCOUNT.py
@@ -1,0 +1,71 @@
+#! /usr/bin/env python
+#
+# Probably we are python2, but use python3 syntax as much as possible
+from __future__ import print_function, unicode_literals
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+def setupConfigurableTest(threads=1, procs=1, time=10.0, interval=1, invoke=False):
+    '''Wrap the class definition in a function to allow arguments to be passed'''
+    class configurableProcessMonitor(unittest.TestCase):
+        def test_runTestWithParams(self):
+            burn_cmd = ['./burner', '--time', str(time)]
+            if threads != 1:
+                burn_cmd.extend(['--threads', str(threads)])
+            if procs != 1:
+                burn_cmd.extend(['--procs', str(procs)])
+
+            prmon_cmd = ['../prmon', '--interval', str(interval)]
+            if invoke:
+                prmon_cmd.append('--')
+                prmon_cmd.extend(burn_cmd)
+                prmon_p = subprocess.Popen(prmon_cmd, shell = False)
+
+                prmon_rc = prmon_p.wait()
+            else:
+                burn_p = subprocess.Popen(burn_cmd, shell = False)
+    
+                prmon_cmd.extend(['--pid', str(burn_p.pid)])
+                prmon_p = subprocess.Popen(prmon_cmd, shell = False)
+    
+                burn_rc = burn_p.wait()
+                prmon_rc = prmon_p.wait()
+    
+            self.assertEqual(prmon_rc, 0, "Non-zero return code from prmon")
+
+            with open("prmon.json") as infile:
+                prmonJSON = json.load(infile)
+
+                # Simple Process and Thread counting test 
+                totPROC      = prmonJSON["Max"]["nprocs"] 
+                totTHREAD    = prmonJSON["Max"]["nthreads"]
+                expectPROC   = procs
+                expectTHREAD = procs*threads 
+                self.assertAlmostEqual(totPROC, expectPROC, msg = "Inconsistent value for number of processes "
+                             "(expected {0}, got {1})".format(expectPROC, totPROC))
+                self.assertAlmostEqual(totTHREAD, expectTHREAD, msg = "Inconsistent value for number of total threads "
+                                "(expected {0}, got {1}".format(expectTHREAD, totTHREAD))
+                    
+    return configurableProcessMonitor
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Configurable test runner")
+    parser.add_argument('--threads', type=int, default=1)
+    parser.add_argument('--procs', type=int, default=1)
+    parser.add_argument('--time', type=float, default=10)
+    parser.add_argument('--interval', type=int, default=1)
+    parser.add_argument('--invoke', dest='invoke', action='store_true', default=False)
+
+    args = parser.parse_args()
+    # Stop unittest from being confused by the arguments
+    sys.argv=sys.argv[:1]
+    
+    cpm = setupConfigurableTest(args.threads,args.procs,args.time,args.interval,args.invoke)
+    
+    unittest.main()


### PR DESCRIPTION
Hi guys,

Coming back to this, I added a new class that counts the number of processes and threads that we're listening to. The text file includes the numbers at the time of sampling, while the JSON includes the maximum and average values. I also added a simple unit test that checks the logic. Things look to be working OK. Any comments are most welcome as always.

Best,
Serhan

cc-ing @sciaba