### PR TITLE
Add Zenodo "concept" DOI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [license-img]: https://img.shields.io/github/license/hsf/prmon.svg
 [license-url]: https://github.com/hsf/prmon/blob/master/LICENSE
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2554202.svg)](https://doi.org/10.5281/zenodo.2554202)
+
 The PRocess MONitor is a small stand alone program that can monitor
 the resource consumption of a process and its children. This is
 useful in the context of the WLCG/HSF working group to evaluate


### PR DESCRIPTION
The Zenodo concept DOI for software referrers generically to the software
as a whole (as opposed to specific releases, which will have different DOIs).
When resolved the concept DOI automatically points to the latest release.
See http://help.zenodo.org/#versioning.