### PR TITLE
Adding CPU frequency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `prmon` binary is invoked with the following arguments:
 
 ```sh
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
-      [--interval 30] [--netdev DEV] \
+      [--interval 30] [--store-cpu-freq] [--netdev DEV] \
       [-- prog arg arg ...]
 ```
 
@@ -81,6 +81,7 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
 * `--filename` output file for timestamped monitored values
 * `--json-summmary` output file for summary data written in JSON format
 * `--interval` time, in seconds, between monitoring snapshots
+* `--store-cpu-freq` flag that turns-on cpu frequency information collection 
 * `--netdev` restricts network statistics to one (or more) network devices
 * `--` after this argument the following arguments are treated as a program to invoke
   and remaining arguments are passed to it; `prmon` will then monitor this process

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(prmon src/prmon.cpp
 					 src/pidutils.cpp
 					 src/netmon.cpp
 					 src/iomon.cpp
+					 src/cpuinfo.cpp
 					 src/cpumon.cpp
 					 src/countmon.cpp
 					 src/wallmon.cpp

--- a/package/src/cpuinfo.cpp
+++ b/package/src/cpuinfo.cpp
@@ -44,8 +44,8 @@ int cpuinfo::get_number_of_cpus() {
   return nCPUs;
 }
 
-// Method to get the processor clock speeds
-std::vector<float> cpuinfo::get_processor_clock_speeds() {
+// Method to get the processor clock freqs
+std::vector<float> cpuinfo::get_processor_clock_freqs() {
   std::vector<float> result;
 
   std::ifstream cpuInfoFile{"/proc/cpuinfo"};
@@ -63,7 +63,7 @@ std::vector<float> cpuinfo::get_processor_clock_speeds() {
     if (splitIdx != std::string::npos) val = line.substr(splitIdx + 1);
     if (line.size() >= key.size() && line.compare(0, key.size(), key) == 0) {
        result.push_back(std::stof(val));
-    } // end of filling clock speeds - order doesn't change 
+    } // end of filling clock freqs - order doesn't change
   } // end of reading cpuInfoFile  
 
   cpuInfoFile.close();
@@ -72,8 +72,9 @@ std::vector<float> cpuinfo::get_processor_clock_speeds() {
 }
 
 // Method to get the scaling information
-int cpuinfo::cpu_scaling_info(int nCPUs) {
-  bool result = false;
+// 0 for false, 1 for true, 2 for error
+unsigned int cpuinfo::cpu_scaling_info(int nCPUs) {
+  unsigned int result = 0;
 
   for(int cpu = 0; cpu < nCPUs; ++cpu) {
     std::string fileName = "/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/cpufreq/scaling_governor";
@@ -81,15 +82,15 @@ int cpuinfo::cpu_scaling_info(int nCPUs) {
     std::ifstream governorFile{fileName};
     if(!governorFile.is_open()) {
       std::cerr << "Failed to open " << fileName << std::endl;
-      return -1;
+      return 2;
     }
 
-    // The governer file has a single line 
+    // The governer file has a single line
     std::string line; 
-    if(std::getline(governorFile,line) && line != "performance") { result = true; break; }
+    if(std::getline(governorFile,line) && line != "performance") { result = 1; break; }
 
     governorFile.close();
   } // end of looping over cpus
 
-  return static_cast<int>(result);
+  return result;
 }

--- a/package/src/cpuinfo.cpp
+++ b/package/src/cpuinfo.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) CERN, 2019
+
+// A few helper functions to get CPU information
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "cpuinfo.h"
+
+// Method to get the total number of processors
+int cpuinfo::get_number_of_cpus() {
+  int nCPUs = 0, maxId = -1;
+
+  std::ifstream cpuInfoFile{"/proc/cpuinfo"};
+  if(!cpuInfoFile.is_open()) {
+    std::cerr << "Failed to open /proc/cpuinfo" << std::endl;
+    return -1;
+  }
+
+  const std::string key = "processor";
+  std::string line;
+  while(std::getline(cpuInfoFile,line)) {
+    if (line.empty()) continue;
+    size_t splitIdx = line.find(":");
+    std::string val;
+    if (splitIdx != std::string::npos) val = line.substr(splitIdx + 1);
+    if (line.size() >= key.size() && line.compare(0, key.size(), key) == 0) {
+      nCPUs++;
+      if(!val.empty()) {
+        int curId = std::stoi(val);
+        maxId = std::max(curId, maxId); 
+      } // end of getting maxId
+    } // end of incrementing nCPUs 
+  } // end of reading cpuInfoFile  
+
+  cpuInfoFile.close();
+
+  // Consistency check
+  if(nCPUs != (maxId + 1)) {
+    std::cout << "CPU ID assignment in /proc/cpuinfo seems fishy!" << std::endl;
+  }
+
+  return nCPUs;
+}
+
+// Method to get the processor clock speeds
+std::vector<float> cpuinfo::get_processor_clock_speeds() {
+  std::vector<float> result;
+
+  std::ifstream cpuInfoFile{"/proc/cpuinfo"};
+  if(!cpuInfoFile.is_open()) {
+    std::cerr << "Failed to open /proc/cpuinfo" << std::endl;
+    return result;
+  }
+
+  const std::string key = "cpu MHz";
+  std::string line;
+  while(std::getline(cpuInfoFile,line)) {
+    if (line.empty()) continue;
+    size_t splitIdx = line.find(":");
+    std::string val;
+    if (splitIdx != std::string::npos) val = line.substr(splitIdx + 1);
+    if (line.size() >= key.size() && line.compare(0, key.size(), key) == 0) {
+       result.push_back(std::stof(val));
+    } // end of filling clock speeds - order doesn't change 
+  } // end of reading cpuInfoFile  
+
+  cpuInfoFile.close();
+
+  return result;
+}
+
+// Method to get the scaling information
+int cpuinfo::cpu_scaling_info(int nCPUs) {
+  bool result = false;
+
+  for(int cpu = 0; cpu < nCPUs; ++cpu) {
+    std::string fileName = "/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/cpufreq/scaling_governor";
+
+    std::ifstream governorFile{fileName};
+    if(!governorFile.is_open()) {
+      std::cerr << "Failed to open " << fileName << std::endl;
+      return -1;
+    }
+
+    // The governer file has a single line 
+    std::string line; 
+    if(std::getline(governorFile,line) && line != "performance") { result = true; break; }
+
+    governorFile.close();
+  } // end of looping over cpus
+
+  return static_cast<int>(result);
+}

--- a/package/src/cpuinfo.h
+++ b/package/src/cpuinfo.h
@@ -6,10 +6,11 @@
 namespace cpuinfo {
   // Method to get the total number of processors
   int get_number_of_cpus();
-  // Method to get the processor clock speeds
-  std::vector<float> get_processor_clock_speeds(); 
+  // Method to get the processor clock freqs
+  std::vector<float> get_processor_clock_freqs();
   // Method to get the scaling information
-  int cpu_scaling_info(int nCPUs);
+  // 0 for false, 1 for true, 2 for error
+  unsigned int cpu_scaling_info(int nCPUs);
 }
 
 #endif // CPUINFO_H

--- a/package/src/cpuinfo.h
+++ b/package/src/cpuinfo.h
@@ -1,0 +1,15 @@
+#ifndef CPUINFO_H
+#define CPUINFO_H
+
+#include <vector>
+
+namespace cpuinfo {
+  // Method to get the total number of processors
+  int get_number_of_cpus();
+  // Method to get the processor clock speeds
+  std::vector<float> get_processor_clock_speeds(); 
+  // Method to get the scaling information
+  int cpu_scaling_info(int nCPUs);
+}
+
+#endif // CPUINFO_H

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -15,6 +15,10 @@
 // after construction
 cpumon::cpumon() : cpu_params{prmon::default_cpu_params}, cpu_stats{},
   m_num_cpus{cpuinfo::get_number_of_cpus()} {
+  // Make this configurable!!! SERHAN
+  for (int idx = 0; idx < m_num_cpus; ++idx) {
+    cpu_params.push_back("CPU" + std::to_string(idx));
+  }
   for (const auto& cpu_param : cpu_params) cpu_stats[cpu_param] = 0;
 }
 
@@ -41,12 +45,15 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
     stat_entries.clear();
   }
   for (auto& stat : cpu_stats) stat.second /= sysconf(_SC_CLK_TCK);
-  // CPU scaling information is independent of the processes
-  // Update how we fill the JSON to accomodate the new parameter!
+  // CPU scaling and clock speed information is independent of the processes - SERHAN
+  // Update how we fill the JSON to accomodate the new parameters!
+  // Fix the types etc. as well - this is just a proof of concept
   cpu_stats["cpu_scaling"] = cpuinfo::cpu_scaling_info(m_num_cpus);
-  // call cpuinfo::get_processor_clock_speeds() to get clock speeds
-  // currently params are const, we need to allow this to change
-  // since the number of columns will depend on the number of processors
+  int idx = 0;
+  for (auto val : cpuinfo::get_processor_clock_speeds()) {
+    cpu_stats["CPU" + std::to_string(idx)] = val;
+    idx++;
+  }
 }
 
 // Return the summed counters

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -21,6 +21,9 @@ class cpumon final : public Imonitor {
   // Container for total stats
   std::map<std::string, unsigned long long> cpu_stats;
 
+  // Number of total processors on the machine
+  const int m_num_cpus;
+
  public:
   cpumon();
 

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -20,12 +20,21 @@ class cpumon final : public Imonitor {
 
   // Container for total stats
   std::map<std::string, unsigned long long> cpu_stats;
+  std::map<std::string, unsigned long long> cpu_peak_stats;
+  std::map<std::string, unsigned long long> cpu_average_stats;
+  std::map<std::string, unsigned long long> cpu_total_stats;
 
   // Number of total processors on the machine
   const int m_num_cpus;
 
+  // Store (or not) the cpu clock freq information
+  bool m_store_cpu_freq;
+
+  // Counter for number of iterations
+  unsigned long m_iterations;
+
  public:
-  cpumon();
+  cpumon(bool store_cpu_freq);
 
   void update_stats(const std::vector<pid_t>& pids);
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -60,7 +60,7 @@ void SignalChildHandler(int /*signal*/) {
   }
 }
 
-int MemoryMonitor(const pid_t mpid, const std::string filename,
+int ProcessMonitor(const pid_t mpid, const std::string filename,
                   const std::string jsonSummary, const unsigned int interval,
                   bool store_cpu_freq, const std::vector<std::string> netdevs) {
   signal(SIGUSR1, SignalCallbackHandler);
@@ -325,7 +325,7 @@ int main(int argc, char* argv[]) {
       std::cerr << "Bad PID to monitor.\n";
       return 1;
     }
-    MemoryMonitor(pid, filename, jsonSummary, interval, store_cpu_freq, netdevs);
+    ProcessMonitor(pid, filename, jsonSummary, interval, store_cpu_freq, netdevs);
   } else {
     if (child_args == argc) {
       std::cerr << "Found marker for child program to execute, but with no program argument.\n";
@@ -335,7 +335,7 @@ int main(int argc, char* argv[]) {
     if( child == 0 ) {
       execvp(argv[child_args],&argv[child_args]);
     } else if ( child > 0 ) {
-      MemoryMonitor(child, filename, jsonSummary, interval, store_cpu_freq, netdevs);
+      ProcessMonitor(child, filename, jsonSummary, interval, store_cpu_freq, netdevs);
     }
   }
 

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -7,5 +7,5 @@
 #include <string>
 
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
-                  unsigned int interval,
+                  unsigned int interval, bool store_cpu_freq,
                   const std::vector<std::string> netdevs);

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -6,6 +6,6 @@
 #include <vector>
 #include <string>
 
-int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
+int ProcessMonitor(pid_t mpid, char* filename, char* jsonSummary,
                   unsigned int interval, bool store_cpu_freq,
                   const std::vector<std::string> netdevs);

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -19,7 +19,7 @@ namespace prmon {
   const size_t uptime_pos = 21;
 
   // Default parameter lists for monitor classes
-  const static std::vector<std::string> default_cpu_params{"utime", "stime"};
+  const static std::vector<std::string> default_cpu_params{"utime", "stime", "cpu_scaling"};
   const static std::vector<std::string> default_network_if_params{
       "rx_bytes", "rx_packets", "tx_bytes", "tx_packets"};
   const static std::vector<std::string> default_wall_params{"wtime"};


### PR DESCRIPTION
This PR addresses #97. The executable now accepts a boolean, `--store-cpu-freq` (or `-s` in short), which turns on processor frequency information collection. If enabled (off by default), we have new columns in the text file that read `CPUX` and the clock freq at the time of sampling is stored in MHz. The JSON file will have the average and peak values as well.

Regardless of the above, we now store an additional column named `cpu_scaling` by default in the text file. This holds information about whether or not the CPU scaling is on. We store 0 for false, 1 for true and 2 in case something goes wrong in the collection. The JSON file only contains the peak value as the average doesn't make much sense for this guy.

Needlessly to say I tested everything locally and all checks out. Given that this is a fairly substantial update I'd appreciate a careful check/comments/suggestions. I'm explicitly cc-ing @sciaba in case he wants to test this earlier.