### PR TITLE
Implement average values as doubles

### DIFF
--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -23,7 +23,7 @@ class Imonitor {
 
   virtual std::map<std::string, unsigned long long> const get_text_stats() = 0;
   virtual std::map<std::string, unsigned long long> const get_json_total_stats() = 0;
-  virtual std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks) = 0;
+  virtual std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks) = 0;
 
 };
 

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 
 #include "countmon.h"
 #include "utils.h"
@@ -49,7 +49,7 @@ void countmon::update_stats(const std::vector<pid_t>& pids) {
     if(count_stats[count_param] > count_peak_stats[count_param])
       count_peak_stats[count_param] = count_stats[count_param];
     count_total_stats[count_param] += count_stats[count_param];
-    count_average_stats[count_param] = count_total_stats[count_param] / iterations; 
+    count_average_stats[count_param] = double(count_total_stats[count_param]) / iterations; 
   }
 }
 
@@ -64,7 +64,7 @@ std::map<std::string, unsigned long long> const countmon::get_json_total_stats()
 }
 
 // An the averages 
-std::map<std::string, unsigned long long> const countmon::get_json_average_stats(
+std::map<std::string, double> const countmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   return count_average_stats;
 }

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 //
 // Process and thread number monitoring class
 //
@@ -21,7 +21,7 @@ class countmon final : public Imonitor {
   // Container for total stats
   std::map<std::string, unsigned long long> count_stats;
   std::map<std::string, unsigned long long> count_peak_stats;
-  std::map<std::string, unsigned long long> count_average_stats;
+  std::map<std::string, double> count_average_stats;
   std::map<std::string, unsigned long long> count_total_stats;
 
   // Counter for number of iterations
@@ -35,7 +35,7 @@ class countmon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 
 #include "cpumon.h"
 #include "utils.h"
@@ -52,8 +52,8 @@ std::map<std::string, unsigned long long> const cpumon::get_json_total_stats() {
 }
 
 // For CPU time there's nothing to return for an average
-std::map<std::string, unsigned long long> const cpumon::get_json_average_stats(
+std::map<std::string, double> const cpumon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, unsigned long long> empty_average_stats{};
+  std::map<std::string, double> empty_average_stats{};
   return empty_average_stats;
 }

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 //
 // CPU monitoring class
 //
@@ -29,7 +29,7 @@ class cpumon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 
 #include "iomon.h"
 #include "utils.h"
@@ -45,12 +45,12 @@ std::map<std::string, unsigned long long> const iomon::get_json_total_stats() {
 }
 
 // For JSON averages, divide by elapsed time
-std::map<std::string, unsigned long long> const iomon::get_json_average_stats(
+std::map<std::string, double> const iomon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, unsigned long long> json_average_stats{};
+  std::map<std::string, double> json_average_stats{};
   for (const auto& io_param : io_stats) {
     json_average_stats[io_param.first] =
-        (io_param.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
+        double(io_param.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 //
 // I/O monitoring class
 //
@@ -28,7 +28,7 @@ class iomon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 
 #include "memmon.h"
 #include "utils.h"
@@ -55,7 +55,7 @@ void memmon::update_stats(const std::vector<pid_t>& pids) {
     if (mem_stats[mem_param] > mem_peak_stats[mem_param])
       mem_peak_stats[mem_param] = mem_stats[mem_param];
     mem_total_stats[mem_param] += mem_stats[mem_param];
-    mem_average_stats[mem_param] = mem_total_stats[mem_param] / iterations;
+    mem_average_stats[mem_param] = double(mem_total_stats[mem_param]) / iterations;
   }
 }
 
@@ -71,7 +71,7 @@ std::map<std::string, unsigned long long> const memmon::get_json_total_stats() {
 
 // Average values are calculated already for us based on the iteration
 // count
-std::map<std::string, unsigned long long> const memmon::get_json_average_stats(
+std::map<std::string, double> const memmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   return mem_average_stats;
 }

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 //
 // Memory monitoring class
 //
@@ -20,7 +20,7 @@ class memmon final : public Imonitor {
   // Container for total stats
   std::map<std::string, unsigned long long> mem_stats;
   std::map<std::string, unsigned long long> mem_peak_stats;
-  std::map<std::string, unsigned long long> mem_average_stats;
+  std::map<std::string, double> mem_average_stats;
   std::map<std::string, unsigned long long> mem_total_stats;
 
   // Counter for number of iterations
@@ -35,7 +35,7 @@ class memmon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2018
+// Copyright (C) CERN, 2020
 
 #include "netmon.h"
 #include "utils.h"
@@ -97,10 +97,11 @@ std::map<std::string, unsigned long long> const netmon::get_json_total_stats() {
 }
 
 // For JSON averages, divide by elapsed time
-std::map<std::string, unsigned long long> const netmon::get_json_average_stats(unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, unsigned long long> json_average_stats = get_text_stats();
-  for (auto& stat : json_average_stats) {
-    stat.second = (stat.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
+std::map<std::string, double> const netmon::get_json_average_stats(unsigned long long elapsed_clock_ticks) {
+  std::map<std::string, unsigned long long> text_stats = get_text_stats();
+  std::map<std::string, double> json_average_stats{};
+  for (auto& stat : text_stats) {
+    json_average_stats[stat.first] = double(stat.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -66,7 +66,7 @@ class netmon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
 

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -81,8 +81,8 @@ std::map<std::string, unsigned long long> const wallmon::get_json_total_stats() 
 }
 
 // For walltime there's nothing to return for an average
-std::map<std::string, unsigned long long> const wallmon::get_json_average_stats(
+std::map<std::string, double> const wallmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, unsigned long long> empty_average_stats{};
+  std::map<std::string, double> empty_average_stats{};
   return empty_average_stats;
 }

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -37,7 +37,7 @@ class wallmon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, unsigned long long> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();


### PR DESCRIPTION
Having average value calculations as unsigned integers was producing harsh
rounding errors for small valued quantities (like nprocs, nthreads). These are
now implemented as double precision values and get serialised as
numbers in JSON with decimal fractions.

There is a slight drawback that the decimal part is designed in nlohmann::json
to avoid precision loss, so sometimes a very high number of DPs are printed.
However, there doesn't seem to be any way to adjust this without manually
massaging the actual numerical values (there are various issues in
https://github.com/nlohmann/json where this is discussed).

An example is:

```
a3febc5a3b43 [hsf]:prmon-build$ cat prmon.json 
{
    "Avg": {
        "nprocs": 1.0,
        "nthreads": 5.0,
        "pss": 1813.0,
        "rchar": 846.1538461538462,
        "read_bytes": 0.0,
        "rss": 3528.0,
        "rx_bytes": 0.0,
        "rx_packets": 0.0,
        "swap": 0.0,
        "tx_bytes": 0.0,
        "tx_packets": 0.0,
        "vmem": 55876.0,
        "wchar": 8.333333333333334,
        "write_bytes": 0.0
    },
    "Max": {
        "nprocs": 1,
        "nthreads": 5,
        "pss": 1813,
        "rchar": 5280,
        "read_bytes": 0,
        "rss": 3528,
        "rx_bytes": 0,
        "rx_packets": 0,
        "stime": 0,
        "swap": 0,
        "tx_bytes": 0,
        "tx_packets": 0,
        "utime": 24,
        "vmem": 55876,
        "wchar": 52,
        "write_bytes": 0,
        "wtime": 6
    }
}
```

Fixes #108 