### PR TITLE
Update to devtoolset-8 in CentOS7 test container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ install:
 # Light customisation of build for different container images
 script:
   - if [ "$DIMAGE" = graemeastewart/u16-dev ]; then docker run -e CXX=g++-7 -e CC=gcc-7 -v $(pwd):/mnt $DIMAGE /mnt/.travis-scripts/build-test.sh; fi
-  - if [ "$DIMAGE" = graemeastewart/c7-dev ]; then docker run -e CMAKE=cmake3 -v $(pwd):/mnt $DIMAGE scl enable devtoolset-7 /mnt/.travis-scripts/build-test.sh; fi
+  - if [ "$DIMAGE" = graemeastewart/c7-dev ]; then docker run -e CMAKE=cmake3 -v $(pwd):/mnt $DIMAGE scl enable devtoolset-8 /mnt/.travis-scripts/build-test.sh; fi
   - if [ "$DIMAGE" = graemeastewart/u18-dev ]; then docker run -e CMAKE_EXTRA="-Dnlohmann_json_DIR=/usr/lib/cmake" -v $(pwd):/mnt $DIMAGE /mnt/.travis-scripts/build-test.sh; fi


### PR DESCRIPTION
Trivial fix to use gcc8 in the C7 container, instead of gcc7
