### PR TITLE
Plugin registry implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 .project
 *.pyc
 .cproject
+build/
+.vscode*
+*code-workspace

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "Imonitor.h"
+#include "registry.h"
 
 class countmon final : public Imonitor {
  private:
@@ -38,5 +39,6 @@ class countmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
+REGISTER_SUBCLASS0(Imonitor, countmon, "countmon")
 
 #endif  // PRMON_COUNTMON_H

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -39,6 +39,6 @@ class countmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
-REGISTER_SUBCLASS0(Imonitor, countmon, "countmon")
+REGISTER_MONITOR(Imonitor, countmon, "countmon", "yeah, like count some stuff ok")
 
 #endif  // PRMON_COUNTMON_H

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -39,6 +39,6 @@ class countmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
-REGISTER_MONITOR(Imonitor, countmon, "countmon", "yeah, like count some stuff ok")
+REGISTER_MONITOR(Imonitor, countmon, "Monitor number of processes and threads")
 
 #endif  // PRMON_COUNTMON_H

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "Imonitor.h"
+#include "registry.h"
 
 class cpumon final : public Imonitor {
  private:
@@ -32,5 +33,6 @@ class cpumon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
+REGISTER_MONITOR(Imonitor, cpumon, "Monitor cpu time used")
 
 #endif  // PRMON_CPUMON_H

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Imonitor.h"
+#include "registry.h"
 
 class iomon final : public Imonitor {
  private:
@@ -31,5 +32,6 @@ class iomon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
+REGISTER_MONITOR(Imonitor, iomon, "Monitor input and output activity")
 
 #endif  // PRMON_IOMON_H

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Imonitor.h"
+#include "registry.h"
 
 class memmon final : public Imonitor {
  private:
@@ -38,5 +39,6 @@ class memmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
+REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")
 
 #endif  // PRMON_MEMMON_H

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "Imonitor.h"
+#include "registry.h"
 
 class netmon final : public Imonitor {
  private:
@@ -69,5 +70,6 @@ class netmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
 };
+REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")
 
 #endif  // PRMON_NETMON_H

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -78,9 +78,9 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
   //countmon count_monitor{};
   monitors.push_back(countmon_p.get());
 
-  auto m = registry::Registry<Imonitor>::get_map();
+  auto m = registry::Registry<Imonitor>::ListRegistered();
   for( const auto& n : m ) {
-    std::cout << "Key:[" << n.first << "] Value:[" << n.second << "]\n";
+    std::cout << n << " - " << registry::Registry<Imonitor>::GetDescription(n) << std::endl;
   }
 
   // Wall clock monitoring

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -15,13 +15,17 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <unordered_map>
 #include <mutex>
 #include <sstream>
 #include <thread>
 #include <vector>
 #include <iomanip>
+#include <memory>
 
 #include <nlohmann/json.hpp>
+
+#include "registry.h"
 
 #include "cpumon.h"
 #include "iomon.h"
@@ -70,8 +74,14 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
   std::vector<Imonitor*> monitors{};
 
   // Number of processes and threads monitoring
-  countmon count_monitor{};
-  monitors.push_back(&count_monitor);
+  std::unique_ptr<Imonitor> countmon_p(registry::Registry<Imonitor>::Create("countmon"));
+  //countmon count_monitor{};
+  monitors.push_back(countmon_p.get());
+
+  auto m = registry::Registry<Imonitor>::get_map();
+  for( const auto& n : m ) {
+    std::cout << "Key:[" << n.first << "] Value:[" << n.second << "]\n";
+  }
 
   // Wall clock monitoring
   wallmon wall_monitor{};

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -75,13 +75,16 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
 
   // Number of processes and threads monitoring
   std::unique_ptr<Imonitor> countmon_p(registry::Registry<Imonitor>::Create("countmon"));
-  //countmon count_monitor{};
-  monitors.push_back(countmon_p.get());
+  std::cout << countmon_p.get() << std::endl;
+  if (countmon_p) monitors.push_back(countmon_p.get());
 
   auto m = registry::Registry<Imonitor>::ListRegistered();
   for( const auto& n : m ) {
     std::cout << n << " - " << registry::Registry<Imonitor>::GetDescription(n) << std::endl;
   }
+
+  std::unique_ptr<Imonitor> test(registry::Registry<Imonitor>::Create("foo"));
+  std::cout << test.get() << std::endl;
 
   // Wall clock monitoring
   wallmon wall_monitor{};

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -74,16 +74,16 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
   std::vector<Imonitor*> monitors{};
 
   // Number of processes and threads monitoring
-  std::unique_ptr<Imonitor> countmon_p(registry::Registry<Imonitor>::Create("countmon"));
+  std::unique_ptr<Imonitor> countmon_p(registry::Registry<Imonitor>::create("countmon"));
   std::cout << countmon_p.get() << std::endl;
   if (countmon_p) monitors.push_back(countmon_p.get());
 
-  auto m = registry::Registry<Imonitor>::ListRegistered();
+  auto m = registry::Registry<Imonitor>::list_registered();
   for( const auto& n : m ) {
-    std::cout << n << " - " << registry::Registry<Imonitor>::GetDescription(n) << std::endl;
+    std::cout << n << " - " << registry::Registry<Imonitor>::get_description(n) << std::endl;
   }
 
-  std::unique_ptr<Imonitor> test(registry::Registry<Imonitor>::Create("foo"));
+  std::unique_ptr<Imonitor> test(registry::Registry<Imonitor>::create("foo"));
   std::cout << test.get() << std::endl;
 
   // Wall clock monitoring

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -6,74 +6,29 @@
 #include <functional>
 #include <iostream>
 #include <string>
-#include <unordered_map>
+#include <map>
+#include <vector>
 
 namespace registry {
 
 // Utility macros
-#define REGISTRY_SPACE
-#define REGISTRY_CONCAT(...) __VA_ARGS__
-#define REGISTRY_GET_MACRO(_0, _1, _2, _3, _4, NAME, ...) NAME
-
-#define REGISTER_SUBCLASS_W_IDENTIFIER(Base, Derived, Identifier, ...) \
-    REGISTRY_GET_MACRO(_0, ##__VA_ARGS__, \
-        REGISTER_SUBCLASS4, \
-        REGISTER_SUBCLASS3, \
-        REGISTER_SUBCLASS2, \
-        REGISTER_SUBCLASS1, \
-        REGISTER_SUBCLASS0)(Base, Derived, #Identifier, ##__VA_ARGS__)
-
-#define REGISTER_SUBCLASS(Base, Derived, ...) \
-    REGISTER_SUBCLASS_W_IDENTIFIER(Base, Derived, Derived, ##__VA_ARGS__)
-
 #define REGISTRY_CTOR(Base, Derived, params, param_names) \
   [](params) -> Base* { return new Derived(param_names); }
     
-#define REGISTER_SUBCLASS0(Base, Derived, Identifier) \
+#define REGISTER_MONITOR(Base, Derived, Identifier, Description) \
   static bool _registered_##Derived = \
       registry::Registry<Base>::Register(Identifier, \
-          REGISTRY_CTOR(Base, Derived,,));
+          REGISTRY_CTOR(Base, Derived,,), Description);
 
-#define REGISTER_SUBCLASS1(Base, Derived, Identifier, dtype1) \
-  static bool _registered_##Derived = \
-      registry::Registry<Base, dtype1>::Register(Identifier, \
-          REGISTRY_CTOR(Base, Derived, \
-              dtype1 REGISTRY_SPACE arg1, arg1));
 
-#define REGISTER_SUBCLASS2(Base, Derived, Identifier, dtype1, dtype2) \
-  static bool _registered_##Derived = \
-      registry::Registry<Base, dtype1, dtype2>::Register(Identifier, \
-          REGISTRY_CTOR(Base, Derived, \
-              REGISTRY_CONCAT(dtype1 REGISTRY_SPACE arg1, \
-                              dtype2 REGISTRY_SPACE arg2), \
-              REGISTRY_CONCAT(arg1, arg2)));
-
-#define REGISTER_SUBCLASS3(Base, Derived, Identifier, dtype1, dtype2, dtype3) \
-  static bool _registered_##Derived = \
-      registry::Registry<Base, dtype1, dtype2, dtype3>::Register(Identifier, \
-          REGISTRY_CTOR(Base, Derived, \
-              REGISTRY_CONCAT(dtype1 REGISTRY_SPACE arg1, \
-                              dtype2 REGISTRY_SPACE arg2, \
-                              dtype3 REGISTRY_SPACE arg3), \
-              REGISTRY_CONCAT(arg1, arg2, arg3)));
-
-#define REGISTER_SUBCLASS4(Base, Derived, Identifier, dtype1, dtype2, dtype3, \
-                           dtype4) \
-  static bool _registered_##Derived = \
-      registry::Registry<Base, dtype1, dtype2, dtype3, dtype4>::Register( \
-          Identifier, \
-          REGISTRY_CTOR(Base, Derived, \
-              REGISTRY_CONCAT(dtype1 REGISTRY_SPACE arg1, \
-                              dtype2 REGISTRY_SPACE arg2, \
-                              dtype3 REGISTRY_SPACE arg3, \
-                              dtype4 REGISTRY_SPACE arg4), \
-              REGISTRY_CONCAT(arg1, arg2, arg3, arg4)));
+static std::string empty = "";
 
 template<typename T, typename ... Pack>
 class Registry {
  public:
   using ctor_t = std::function<T*(Pack...)>;
-  using map_t = std::unordered_map<std::string, ctor_t>;
+  using map_t = std::map<std::string, ctor_t>;
+  using desc_t = std::map<std::string, std::string>;
 
   template<typename ... Args>
   static T* Create(const std::string& class_name, Args && ... pack) {
@@ -84,8 +39,9 @@ class Registry {
     return nullptr;
   }
 
-  static bool Register(const std::string& class_name, const ctor_t& ctor) {
+  static bool Register(const std::string& class_name, const ctor_t& ctor, const std::string& description) {
     ctors()[class_name] = ctor;
+    desc()[class_name] = description;
     return true;
   }
 
@@ -95,11 +51,22 @@ class Registry {
 
   static void Unregister(const std::string& class_name) {
     ctors().erase(class_name);
+    desc().erase(class_name);
   }
 
-  const map_t& get_map() {
-    static map_t ctor_map;
-    return ctor_map;
+  static std::vector<std::string> ListRegistered() {
+    std::vector<std::string> list{};
+    for (const auto k : ctors()) {
+      list.push_back(k.first);
+    }
+    return list;
+  }
+
+  static const std::string& GetDescription(const std::string& name) {
+    if (desc().count(name) == 1) {
+      return desc()[name];
+    }
+    return registry::empty;
   }
 
  private:
@@ -107,6 +74,15 @@ class Registry {
     static map_t ctor_map;
     return ctor_map;
   }
+
+  static desc_t& desc() {
+    static desc_t desc_map;
+    return desc_map;
+  }
+  // static const& std::string empty() {
+  //   static std::string empty_string{};
+  //   return empty_string;
+  // }
 
   Registry();
   Registry(const Registry& other);

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -11,77 +11,78 @@
 
 namespace registry {
 
-// Utility macros
-#define REGISTRY_CTOR(Base, Derived, params, param_names) \
-  [](params) -> Base* { return new Derived(param_names); }
+  // Utility macros
+  #define REGISTRY_CTOR(Base, Derived, params, param_names) \
+    [](params) -> Base* { return new Derived(param_names); }
 
-#define REGISTER_MONITOR(Base, Derived, Description) \
-  static bool _registered_##Derived = \
-      registry::Registry<Base>::Register(#Derived, REGISTRY_CTOR(Base, Derived,,), Description);
+  #define REGISTER_MONITOR(Base, Derived, Description) \
+    static bool _registered_##Derived = \
+        registry::Registry<Base>::register_class(#Derived, REGISTRY_CTOR(Base, Derived,,), Description);
 
-static std::string empty_desc = "";
+  // Empty string to return if there is no description
+  static std::string empty_desc = "";
 
-template<typename T, typename ... Pack>
-class Registry {
- public:
-  using ctor_t = std::function<T*(Pack...)>;
-  using map_t = std::map<std::string, ctor_t>;
-  using desc_t = std::map<std::string, std::string>;
+  template<typename T, typename ... Pack>
+  class Registry {
+  public:
+    using ctor_t = std::function<T*(Pack...)>;
+    using map_t = std::map<std::string, ctor_t>;
+    using desc_t = std::map<std::string, std::string>;
 
-  template<typename ... Args>
-  static T* Create(const std::string& class_name, Args && ... pack) {
-    if (ctors().count(class_name) == 1) {
-      return ctors()[class_name](std::forward<Args>(pack)...);
+    template<typename ... Args>
+    static T* create(const std::string& class_name, Args && ... pack) {
+      if (ctors().count(class_name) == 1) {
+        return ctors()[class_name](std::forward<Args>(pack)...);
+      }
+      std::cerr << "Registry: class " << class_name << " is not registered." << std::endl;
+      return nullptr;
     }
-    std::cerr << "Class " << class_name << " not registered." << std::endl;
-    return nullptr;
-  }
 
-  static bool Register(const std::string& class_name, const ctor_t& ctor, const std::string& description) {
-    ctors()[class_name] = ctor;
-    desc()[class_name] = description;
-    return true;
-  }
-
-  static bool IsRegistered(const std::string& class_name) {
-    return ctors().count(class_name) == 1;
-  }
-
-  static void Unregister(const std::string& class_name) {
-    ctors().erase(class_name);
-    desc().erase(class_name);
-  }
-
-  static std::vector<std::string> ListRegistered() {
-    std::vector<std::string> list{};
-    for (const auto k : ctors()) {
-      list.push_back(k.first);
+    static bool register_class(const std::string& class_name, const ctor_t& ctor, const std::string& description) {
+      ctors()[class_name] = ctor;
+      desc()[class_name] = description;
+      return true;
     }
-    return list;
-  }
 
-  static const std::string& GetDescription(const std::string& name) {
-    if (desc().count(name) == 1) {
-      return desc()[name];
+    static bool is_registered(const std::string& class_name) {
+      return ctors().count(class_name) == 1;
     }
-    return registry::empty_desc;
-  }
 
- private:
-  static map_t& ctors() {
-    static map_t ctor_map;
-    return ctor_map;
-  }
+    static void unregister(const std::string& class_name) {
+      ctors().erase(class_name);
+      desc().erase(class_name);
+    }
 
-  static desc_t& desc() {
-    static desc_t desc_map;
-    return desc_map;
-  }
+    static std::vector<std::string> list_registered() {
+      std::vector<std::string> list{};
+      for (const auto k : ctors()) {
+        list.push_back(k.first);
+      }
+      return list;
+    }
 
-  Registry();
-  Registry(const Registry& other);
-  Registry& operator=(const Registry& other);
-};
+    static const std::string& get_description(const std::string& name) {
+      if (desc().count(name) == 1) {
+        return desc()[name];
+      }
+      return registry::empty_desc;
+    }
+
+  private:
+    static map_t& ctors() {
+      static map_t ctor_map;
+      return ctor_map;
+    }
+
+    static desc_t& desc() {
+      static desc_t desc_map;
+      return desc_map;
+    }
+
+    Registry();
+    Registry(const Registry& other);
+    Registry& operator=(const Registry& other);
+  };
 
 }
 

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -14,14 +14,12 @@ namespace registry {
 // Utility macros
 #define REGISTRY_CTOR(Base, Derived, params, param_names) \
   [](params) -> Base* { return new Derived(param_names); }
-    
-#define REGISTER_MONITOR(Base, Derived, Identifier, Description) \
+
+#define REGISTER_MONITOR(Base, Derived, Description) \
   static bool _registered_##Derived = \
-      registry::Registry<Base>::Register(Identifier, \
-          REGISTRY_CTOR(Base, Derived,,), Description);
+      registry::Registry<Base>::Register(#Derived, REGISTRY_CTOR(Base, Derived,,), Description);
 
-
-static std::string empty = "";
+static std::string empty_desc = "";
 
 template<typename T, typename ... Pack>
 class Registry {
@@ -66,7 +64,7 @@ class Registry {
     if (desc().count(name) == 1) {
       return desc()[name];
     }
-    return registry::empty;
+    return registry::empty_desc;
   }
 
  private:
@@ -79,10 +77,6 @@ class Registry {
     static desc_t desc_map;
     return desc_map;
   }
-  // static const& std::string empty() {
-  //   static std::string empty_string{};
-  //   return empty_string;
-  // }
 
   Registry();
   Registry(const Registry& other);

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <memory>
 
 namespace registry {
 
@@ -30,12 +31,12 @@ namespace registry {
     using desc_t = std::map<std::string, std::string>;
 
     template<typename ... Args>
-    static T* create(const std::string& class_name, Args && ... pack) {
+    static std::unique_ptr<T> create(const std::string& class_name, Args && ... pack) {
       if (ctors().count(class_name) == 1) {
-        return ctors()[class_name](std::forward<Args>(pack)...);
+        return std::unique_ptr<T>(ctors()[class_name](std::forward<Args>(pack)...));
       }
       std::cerr << "Registry: class " << class_name << " is not registered." << std::endl;
-      return nullptr;
+      return std::unique_ptr<T>(nullptr);
     }
 
     static bool register_class(const std::string& class_name, const ctor_t& ctor, const std::string& description) {

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -1,0 +1,118 @@
+// Copyright (C) CERN, 2020
+
+#ifndef PRMON_REGISTRY_H
+#define PRMON_REGISTRY_H
+
+#include <functional>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+namespace registry {
+
+// Utility macros
+#define REGISTRY_SPACE
+#define REGISTRY_CONCAT(...) __VA_ARGS__
+#define REGISTRY_GET_MACRO(_0, _1, _2, _3, _4, NAME, ...) NAME
+
+#define REGISTER_SUBCLASS_W_IDENTIFIER(Base, Derived, Identifier, ...) \
+    REGISTRY_GET_MACRO(_0, ##__VA_ARGS__, \
+        REGISTER_SUBCLASS4, \
+        REGISTER_SUBCLASS3, \
+        REGISTER_SUBCLASS2, \
+        REGISTER_SUBCLASS1, \
+        REGISTER_SUBCLASS0)(Base, Derived, #Identifier, ##__VA_ARGS__)
+
+#define REGISTER_SUBCLASS(Base, Derived, ...) \
+    REGISTER_SUBCLASS_W_IDENTIFIER(Base, Derived, Derived, ##__VA_ARGS__)
+
+#define REGISTRY_CTOR(Base, Derived, params, param_names) \
+  [](params) -> Base* { return new Derived(param_names); }
+    
+#define REGISTER_SUBCLASS0(Base, Derived, Identifier) \
+  static bool _registered_##Derived = \
+      registry::Registry<Base>::Register(Identifier, \
+          REGISTRY_CTOR(Base, Derived,,));
+
+#define REGISTER_SUBCLASS1(Base, Derived, Identifier, dtype1) \
+  static bool _registered_##Derived = \
+      registry::Registry<Base, dtype1>::Register(Identifier, \
+          REGISTRY_CTOR(Base, Derived, \
+              dtype1 REGISTRY_SPACE arg1, arg1));
+
+#define REGISTER_SUBCLASS2(Base, Derived, Identifier, dtype1, dtype2) \
+  static bool _registered_##Derived = \
+      registry::Registry<Base, dtype1, dtype2>::Register(Identifier, \
+          REGISTRY_CTOR(Base, Derived, \
+              REGISTRY_CONCAT(dtype1 REGISTRY_SPACE arg1, \
+                              dtype2 REGISTRY_SPACE arg2), \
+              REGISTRY_CONCAT(arg1, arg2)));
+
+#define REGISTER_SUBCLASS3(Base, Derived, Identifier, dtype1, dtype2, dtype3) \
+  static bool _registered_##Derived = \
+      registry::Registry<Base, dtype1, dtype2, dtype3>::Register(Identifier, \
+          REGISTRY_CTOR(Base, Derived, \
+              REGISTRY_CONCAT(dtype1 REGISTRY_SPACE arg1, \
+                              dtype2 REGISTRY_SPACE arg2, \
+                              dtype3 REGISTRY_SPACE arg3), \
+              REGISTRY_CONCAT(arg1, arg2, arg3)));
+
+#define REGISTER_SUBCLASS4(Base, Derived, Identifier, dtype1, dtype2, dtype3, \
+                           dtype4) \
+  static bool _registered_##Derived = \
+      registry::Registry<Base, dtype1, dtype2, dtype3, dtype4>::Register( \
+          Identifier, \
+          REGISTRY_CTOR(Base, Derived, \
+              REGISTRY_CONCAT(dtype1 REGISTRY_SPACE arg1, \
+                              dtype2 REGISTRY_SPACE arg2, \
+                              dtype3 REGISTRY_SPACE arg3, \
+                              dtype4 REGISTRY_SPACE arg4), \
+              REGISTRY_CONCAT(arg1, arg2, arg3, arg4)));
+
+template<typename T, typename ... Pack>
+class Registry {
+ public:
+  using ctor_t = std::function<T*(Pack...)>;
+  using map_t = std::unordered_map<std::string, ctor_t>;
+
+  template<typename ... Args>
+  static T* Create(const std::string& class_name, Args && ... pack) {
+    if (ctors().count(class_name) == 1) {
+      return ctors()[class_name](std::forward<Args>(pack)...);
+    }
+    std::cerr << "Class " << class_name << " not registered." << std::endl;
+    return nullptr;
+  }
+
+  static bool Register(const std::string& class_name, const ctor_t& ctor) {
+    ctors()[class_name] = ctor;
+    return true;
+  }
+
+  static bool IsRegistered(const std::string& class_name) {
+    return ctors().count(class_name) == 1;
+  }
+
+  static void Unregister(const std::string& class_name) {
+    ctors().erase(class_name);
+  }
+
+  const map_t& get_map() {
+    static map_t ctor_map;
+    return ctor_map;
+  }
+
+ private:
+  static map_t& ctors() {
+    static map_t ctor_map;
+    return ctor_map;
+  }
+
+  Registry();
+  Registry(const Registry& other);
+  Registry& operator=(const Registry& other);
+};
+
+}
+
+#endif // PRMON_REGISTRY_H

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "Imonitor.h"
+#include "registry.h"
 
 class wallmon final : public Imonitor {
  private:
@@ -42,5 +43,6 @@ class wallmon final : public Imonitor {
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();
 };
+REGISTER_MONITOR(Imonitor, wallmon, "Monitor wallclock time")
 
 #endif  // PRMON_WALLMON_H


### PR DESCRIPTION
This is not quite finished in it's full implementation, but it is a good time for review as further development comes on top.

Inspired by <https://github.com/psalvaggio/cppregpattern> this is a registry implementaion for prmon.

It makes the code in the main monitor look a lot nicer, as initialisation is now a loop over the registry. I am not completely happy with the pointer grabbed to `wallmon`, but as it's used inside the monitoring loop (to pass wallclock time to the average stats generation) it is needed and I could not think of a better way.

Closes #113 
Helps with making #106 and #107 much easier to implement
