### PR TITLE
Hardware information implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `prmon` binary is invoked with the following arguments:
 
 ```sh
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
-      [--interval 30] [--netdev DEV] \
+      [--interval 30] [--store-hw-info] [--netdev DEV] \
       [-- prog arg arg ...]
 ```
 
@@ -81,6 +81,7 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
 * `--filename` output file for timestamped monitored values
 * `--json-summmary` output file for summary data written in JSON format
 * `--interval` time, in seconds, between monitoring snapshots
+* `--store-hw-info` flag that turns-on hardware information collection
 * `--netdev` restricts network statistics to one (or more) network devices
 * `--` after this argument the following arguments are treated as a program to invoke
   and remaining arguments are passed to it; `prmon` will then monitor this process

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -15,6 +15,8 @@
 #include <string>
 #include <vector>
 
+#include <nlohmann/json.hpp>
+
 class Imonitor {
  public:
   virtual ~Imonitor() {};
@@ -25,7 +27,7 @@ class Imonitor {
   virtual std::map<std::string, unsigned long long> const get_json_total_stats() = 0;
   virtual std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks) = 0;
 
-  virtual std::map<std::string, std::map<std::string, std::string>> const get_hardware_info() = 0;
+  virtual void const get_hardware_info(nlohmann::json& j) = 0;
 };
 
 #endif  // PRMON_IMONITOR_H

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -27,7 +27,7 @@ class Imonitor {
   virtual std::map<std::string, unsigned long long> const get_json_total_stats() = 0;
   virtual std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks) = 0;
 
-  virtual void const get_hardware_info(nlohmann::json& j) = 0;
+  virtual void const get_hardware_info(nlohmann::json& hw_json) = 0;
 };
 
 #endif  // PRMON_IMONITOR_H

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -25,6 +25,7 @@ class Imonitor {
   virtual std::map<std::string, unsigned long long> const get_json_total_stats() = 0;
   virtual std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks) = 0;
 
+  virtual std::map<std::string, std::map<std::string, std::string>> const get_hardware_info() = 0;
 };
 
 #endif  // PRMON_IMONITOR_H

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -68,3 +68,10 @@ std::map<std::string, double> const countmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   return count_average_stats;
 }
+
+// Collect related hardware information
+std::map<std::string, std::map<std::string, std::string>> const countmon::get_hardware_info() {
+  std::map<std::string, std::map<std::string, std::string>> result{};
+  return result; 
+}
+

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -70,6 +70,6 @@ std::map<std::string, double> const countmon::get_json_average_stats(
 }
 
 // Collect related hardware information
-void const countmon::get_hardware_info(nlohmann::json& j) {
+void const countmon::get_hardware_info(nlohmann::json& hw_json) {
   return;
 }

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -12,9 +12,9 @@
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-countmon::countmon() : count_params{prmon::default_count_params},  
+countmon::countmon() : count_params{prmon::default_count_params},
   count_stats{}, count_average_stats{}, count_total_stats{}, iterations{0L} {
-  for (const auto& count_param : count_params) { 
+  for (const auto& count_param : count_params) {
     count_stats[count_param] = 0;
     count_peak_stats[count_param] = 0;
     count_average_stats[count_param] = 0;
@@ -37,8 +37,8 @@ void countmon::update_stats(const std::vector<pid_t>& pids) {
       if (proc_stat) stat_entries.push_back(tmp_str);
     }
     if (stat_entries.size() > prmon::stat_count_read_limit) {
-      count_stats["nprocs"]   += 1L; 
-      count_stats["nthreads"] += std::stol(stat_entries[prmon::num_threads]) - 1L; 
+      count_stats["nprocs"]   += 1L;
+      count_stats["nthreads"] += std::stol(stat_entries[prmon::num_threads]) - 1L;
     }
     stat_entries.clear();
   }
@@ -49,7 +49,7 @@ void countmon::update_stats(const std::vector<pid_t>& pids) {
     if(count_stats[count_param] > count_peak_stats[count_param])
       count_peak_stats[count_param] = count_stats[count_param];
     count_total_stats[count_param] += count_stats[count_param];
-    count_average_stats[count_param] = double(count_total_stats[count_param]) / iterations; 
+    count_average_stats[count_param] = double(count_total_stats[count_param]) / iterations;
   }
 }
 
@@ -63,15 +63,13 @@ std::map<std::string, unsigned long long> const countmon::get_json_total_stats()
   return count_peak_stats;
 }
 
-// An the averages 
+// An the averages
 std::map<std::string, double> const countmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   return count_average_stats;
 }
 
 // Collect related hardware information
-std::map<std::string, std::map<std::string, std::string>> const countmon::get_hardware_info() {
-  std::map<std::string, std::map<std::string, std::string>> result{};
-  return result; 
+void const countmon::get_hardware_info(nlohmann::json& j) {
+  return;
 }
-

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -38,6 +38,9 @@ class countmon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
+  // This is the hardware information getter that runs once
+  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+
 };
 REGISTER_MONITOR(Imonitor, countmon, "Monitor number of processes and threads")
 

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -39,7 +39,7 @@ class countmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  void const get_hardware_info(nlohmann::json& j);
+  void const get_hardware_info(nlohmann::json& hw_json);
 
 };
 REGISTER_MONITOR(Imonitor, countmon, "Monitor number of processes and threads")

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -39,7 +39,7 @@ class countmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+  void const get_hardware_info(nlohmann::json& j);
 
 };
 REGISTER_MONITOR(Imonitor, countmon, "Monitor number of processes and threads")

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -60,7 +60,7 @@ std::map<std::string, double> const cpumon::get_json_average_stats(
 }
 
 // Collect related hardware information
-void const cpumon::get_hardware_info(nlohmann::json& j) {
+void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
 
   // Read some information from /proc/cpuinfo
   std::ifstream cpuInfoFile{"/proc/cpuinfo"};
@@ -87,8 +87,8 @@ void const cpumon::get_hardware_info(nlohmann::json& j) {
           if (metric == "processor") nCPU++;
           else if (metric == "siblings") { if(nSiblings == 0) nSiblings = std::stoi(val); }
           else if (metric == "cpu cores") { if(nCores == 0) nCores = std::stoi(val); }
-          else if (j["HW"]["cpu"][metric].empty()) {
-            j["HW"]["cpu"][metric] = std::regex_replace(val, std::regex("^\\s+|\\s+$"), "");
+          else if (hw_json["HW"]["cpu"][metric].empty()) {
+            hw_json["HW"]["cpu"][metric] = std::regex_replace(val, std::regex("^\\s+|\\s+$"), "");
           }
         } // end of metric check
       } // end of populating metrics
@@ -100,10 +100,10 @@ void const cpumon::get_hardware_info(nlohmann::json& j) {
   // nSiblings = nCoresPerSocket * nThreadsPerCore
   unsigned int nSockets = nCPU / nSiblings;
   unsigned int nThreads = nSiblings / nCores;
-  j["HW"]["cpu"]["nCPU"] = nCPU;
-  j["HW"]["cpu"]["nSockets"] = nSockets;
-  j["HW"]["cpu"]["nCoresPerSocket"] = nCores;
-  j["HW"]["cpu"]["nThreadsPerCore"] = nThreads;
+  hw_json["HW"]["cpu"]["nCPU"] = nCPU;
+  hw_json["HW"]["cpu"]["nSockets"] = nSockets;
+  hw_json["HW"]["cpu"]["nCoresPerSocket"] = nCores;
+  hw_json["HW"]["cpu"]["nThreadsPerCore"] = nThreads;
 
   // Close the file
   cpuInfoFile.close();

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -98,13 +98,13 @@ std::map<std::string, std::map<std::string, std::string>> const cpumon::get_hard
 
   // The clear assumption here is that there is a single type of processor installed
   // nCPU = nSockets * nSiblings
-  // nSiblings = nCores * nThreads
+  // nSiblings = nCoresPerSocket * nThreadsPerCore
   unsigned int nSockets = nCPU / nSiblings;
   unsigned int nThreads = nSiblings / nCores;
   result["cpu"]["nCPU"] = std::to_string(nCPU);
   result["cpu"]["nSockets"] = std::to_string(nSockets);
-  result["cpu"]["nCores"] = std::to_string(nCores);
-  result["cpu"]["nThreads"] = std::to_string(nThreads);
+  result["cpu"]["nCoresPerSocket"] = std::to_string(nCores);
+  result["cpu"]["nThreadsPerCore"] = std::to_string(nThreads);
 
   // Close the file
   cpuInfoFile.close();

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -60,14 +60,13 @@ std::map<std::string, double> const cpumon::get_json_average_stats(
 }
 
 // Collect related hardware information
-std::map<std::string, std::map<std::string, std::string>> const cpumon::get_hardware_info() {
-  std::map<std::string, std::map<std::string, std::string>> result{};
+void const cpumon::get_hardware_info(nlohmann::json& j) {
 
   // Read some information from /proc/cpuinfo
   std::ifstream cpuInfoFile{"/proc/cpuinfo"};
   if(!cpuInfoFile.is_open()) {
     std::cerr << "Failed to open /proc/cpuinfo" << std::endl;
-    return result;
+    return;
   }
 
   // Metrics to read from the input
@@ -88,8 +87,8 @@ std::map<std::string, std::map<std::string, std::string>> const cpumon::get_hard
           if (metric == "processor") nCPU++;
           else if (metric == "siblings") { if(nSiblings == 0) nSiblings = std::stoi(val); }
           else if (metric == "cpu cores") { if(nCores == 0) nCores = std::stoi(val); }
-          else if (result["cpu"][metric].empty()) {
-            result["cpu"][metric] = std::regex_replace(val, std::regex("^\\s+|\\s+$"), "");
+          else if (j["HW"]["cpu"][metric].empty()) {
+            j["HW"]["cpu"][metric] = std::regex_replace(val, std::regex("^\\s+|\\s+$"), "");
           }
         } // end of metric check
       } // end of populating metrics
@@ -101,13 +100,13 @@ std::map<std::string, std::map<std::string, std::string>> const cpumon::get_hard
   // nSiblings = nCoresPerSocket * nThreadsPerCore
   unsigned int nSockets = nCPU / nSiblings;
   unsigned int nThreads = nSiblings / nCores;
-  result["cpu"]["nCPU"] = std::to_string(nCPU);
-  result["cpu"]["nSockets"] = std::to_string(nSockets);
-  result["cpu"]["nCoresPerSocket"] = std::to_string(nCores);
-  result["cpu"]["nThreadsPerCore"] = std::to_string(nThreads);
+  j["HW"]["cpu"]["nCPU"] = nCPU;
+  j["HW"]["cpu"]["nSockets"] = nSockets;
+  j["HW"]["cpu"]["nCoresPerSocket"] = nCores;
+  j["HW"]["cpu"]["nThreadsPerCore"] = nThreads;
 
   // Close the file
   cpuInfoFile.close();
 
-  return result;
+  return;
 }

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -33,7 +33,7 @@ class cpumon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  void const get_hardware_info(nlohmann::json& j);
+  void const get_hardware_info(nlohmann::json& hw_json);
 
 };
 REGISTER_MONITOR(Imonitor, cpumon, "Monitor cpu time used")

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -33,7 +33,7 @@ class cpumon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+  void const get_hardware_info(nlohmann::json& j);
 
 };
 REGISTER_MONITOR(Imonitor, cpumon, "Monitor cpu time used")

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -32,6 +32,9 @@ class cpumon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
+  // This is the hardware information getter that runs once
+  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+
 };
 REGISTER_MONITOR(Imonitor, cpumon, "Monitor cpu time used")
 

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -56,7 +56,6 @@ std::map<std::string, double> const iomon::get_json_average_stats(
 }
 
 // Collect related hardware information
-std::map<std::string, std::map<std::string, std::string>> const iomon::get_hardware_info() {
-  std::map<std::string, std::map<std::string, std::string>> result{};
-  return result; 
+void const iomon::get_hardware_info(nlohmann::json& j) {
+  return;
 }

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -56,6 +56,6 @@ std::map<std::string, double> const iomon::get_json_average_stats(
 }
 
 // Collect related hardware information
-void const iomon::get_hardware_info(nlohmann::json& j) {
+void const iomon::get_hardware_info(nlohmann::json& hw_json) {
   return;
 }

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -54,3 +54,9 @@ std::map<std::string, double> const iomon::get_json_average_stats(
   }
   return json_average_stats;
 }
+
+// Collect related hardware information
+std::map<std::string, std::map<std::string, std::string>> const iomon::get_hardware_info() {
+  std::map<std::string, std::map<std::string, std::string>> result{};
+  return result; 
+}

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -31,6 +31,9 @@ class iomon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
+  // This is the hardware information getter that runs once
+  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+
 };
 REGISTER_MONITOR(Imonitor, iomon, "Monitor input and output activity")
 

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -32,7 +32,7 @@ class iomon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+  void const get_hardware_info(nlohmann::json& j);
 
 };
 REGISTER_MONITOR(Imonitor, iomon, "Monitor input and output activity")

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -32,7 +32,7 @@ class iomon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  void const get_hardware_info(nlohmann::json& j);
+  void const get_hardware_info(nlohmann::json& hw_json);
 
 };
 REGISTER_MONITOR(Imonitor, iomon, "Monitor input and output activity")

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -78,14 +78,13 @@ std::map<std::string, double> const memmon::get_json_average_stats(
 }
 
 // Collect related hardware information
-std::map<std::string, std::map<std::string, std::string>> const memmon::get_hardware_info() {
-  std::map<std::string, std::map<std::string, std::string>> result{};
+void const memmon::get_hardware_info(nlohmann::json& j) {
 
   // Read some information from /proc/meminfo
   std::ifstream memInfoFile{"/proc/meminfo"};
   if(!memInfoFile.is_open()) {
     std::cerr << "Failed to open /proc/meminfo" << std::endl;
-    return result;
+    return;
   }
 
   // Metrics to read from the input
@@ -102,7 +101,8 @@ std::map<std::string, std::map<std::string, std::string>> const memmon::get_hard
       if (val.empty()) continue;
       for (const auto& metric : metrics) {
         if (line.size() >= metric.size() && line.compare(0, metric.size(), metric) == 0) {
-          result["mem"][metric] = std::regex_replace(val, std::regex("^\\s+|\\s+$"), "");
+          val = val.substr(0, val.size()-3); // strip the trailing kB
+          j["HW"]["mem"][metric] = std::stol(std::regex_replace(val, std::regex("^\\s+|\\s+$"), ""));
         } // end of metric check
       } // end of populating metrics
     } // end of seperator check
@@ -111,5 +111,5 @@ std::map<std::string, std::map<std::string, std::string>> const memmon::get_hard
   // Close the file
   memInfoFile.close();
 
-  return result;
+  return;
 }

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -78,7 +78,7 @@ std::map<std::string, double> const memmon::get_json_average_stats(
 }
 
 // Collect related hardware information
-void const memmon::get_hardware_info(nlohmann::json& j) {
+void const memmon::get_hardware_info(nlohmann::json& hw_json) {
 
   // Read some information from /proc/meminfo
   std::ifstream memInfoFile{"/proc/meminfo"};
@@ -102,7 +102,7 @@ void const memmon::get_hardware_info(nlohmann::json& j) {
       for (const auto& metric : metrics) {
         if (line.size() >= metric.size() && line.compare(0, metric.size(), metric) == 0) {
           val = val.substr(0, val.size()-3); // strip the trailing kB
-          j["HW"]["mem"][metric] = std::stol(std::regex_replace(val, std::regex("^\\s+|\\s+$"), ""));
+          hw_json["HW"]["mem"][metric] = std::stol(std::regex_replace(val, std::regex("^\\s+|\\s+$"), ""));
         } // end of metric check
       } // end of populating metrics
     } // end of seperator check

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -75,3 +75,9 @@ std::map<std::string, double> const memmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   return mem_average_stats;
 }
+
+// Collect related hardware information
+std::map<std::string, std::map<std::string, std::string>> const memmon::get_hardware_info() {
+  std::map<std::string, std::map<std::string, std::string>> result{};
+  return result; 
+}

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -39,7 +39,7 @@ class memmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+  void const get_hardware_info(nlohmann::json& j);
 
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -39,7 +39,7 @@ class memmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  void const get_hardware_info(nlohmann::json& j);
+  void const get_hardware_info(nlohmann::json& hw_json);
 
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -38,6 +38,9 @@ class memmon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
+  // This is the hardware information getter that runs once
+  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")
 

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -107,6 +107,6 @@ std::map<std::string, double> const netmon::get_json_average_stats(unsigned long
 }
 
 // Collect related hardware information
-void const netmon::get_hardware_info(nlohmann::json& j) {
+void const netmon::get_hardware_info(nlohmann::json& hw_json) {
   return;
 }

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -107,7 +107,6 @@ std::map<std::string, double> const netmon::get_json_average_stats(unsigned long
 }
 
 // Collect related hardware information
-std::map<std::string, std::map<std::string, std::string>> const netmon::get_hardware_info() {
-  std::map<std::string, std::map<std::string, std::string>> result{};
-  return result; 
+void const netmon::get_hardware_info(nlohmann::json& j) {
+  return;
 }

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -105,3 +105,9 @@ std::map<std::string, double> const netmon::get_json_average_stats(unsigned long
   }
   return json_average_stats;
 }
+
+// Collect related hardware information
+std::map<std::string, std::map<std::string, std::string>> const netmon::get_hardware_info() {
+  std::map<std::string, std::map<std::string, std::string>> result{};
+  return result; 
+}

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -70,7 +70,7 @@ class netmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+  void const get_hardware_info(nlohmann::json& j);
 
 };
 REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -70,7 +70,7 @@ class netmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  void const get_hardware_info(nlohmann::json& j);
+  void const get_hardware_info(nlohmann::json& hw_json);
 
 };
 REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -69,6 +69,9 @@ class netmon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
+  // This is the hardware information getter that runs once
+  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+
 };
 REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -105,8 +105,7 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
   // Collect some hardware information first (if requested)
   if (store_hw_info) {
     for (const auto& monitor : monitors)
-      for( const auto& stat : monitor.second->get_hardware_info())
-        json_summary["HW"][(stat.first).c_str()] = stat.second;
+      monitor.second->get_hardware_info(json_summary);
   }
 
   // See if the kernel is new enough to have /proc/PID/task/PID/children

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -264,7 +264,7 @@ int main(int argc, char* argv[]) {
         << "[--interval, -i TIME]     Seconds between samples (default "
         << default_interval << ")\n"
         << "[--store-hw-info, -s]     Store hardware information (default "
-        << default_store_hw_info << ")\n"
+        << (default_store_hw_info ? "true" : "false") << ")\n"
         << "[--netdev, -n dev]        Network device to monitor (can be given\n"
         << "                          multiple times; default ALL devices)\n"
         << "[--] prog [arg] ...       Instead of monitoring a PID prmon will\n"

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -104,8 +104,8 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
 
   // Collect some hardware information first (if requested)
   if (store_hw_info) {
-    for (const auto monitor : monitors)
-      for( const auto& stat : monitor->get_hardware_info())
+    for (const auto& monitor : monitors)
+      for( const auto& stat : monitor.second->get_hardware_info())
         json_summary["HW"][(stat.first).c_str()] = stat.second;
   }
 

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -7,5 +7,5 @@
 #include <string>
 
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
-                  unsigned int interval,
+                  unsigned int interval, const bool store_hw_info,
                   const std::vector<std::string> netdevs);

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -88,6 +88,6 @@ std::map<std::string, double> const wallmon::get_json_average_stats(
 }
 
 // Collect related hardware information
-void const wallmon::get_hardware_info(nlohmann::json& j) {
+void const wallmon::get_hardware_info(nlohmann::json& hw_json) {
   return;
 }

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -88,7 +88,6 @@ std::map<std::string, double> const wallmon::get_json_average_stats(
 }
 
 // Collect related hardware information
-std::map<std::string, std::map<std::string, std::string>> const wallmon::get_hardware_info() {
-  std::map<std::string, std::map<std::string, std::string>> result{};
-  return result; 
+void const wallmon::get_hardware_info(nlohmann::json& j) {
+  return;
 }

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -86,3 +86,9 @@ std::map<std::string, double> const wallmon::get_json_average_stats(
   std::map<std::string, double> empty_average_stats{};
   return empty_average_stats;
 }
+
+// Collect related hardware information
+std::map<std::string, std::map<std::string, std::string>> const wallmon::get_hardware_info() {
+  std::map<std::string, std::map<std::string, std::string>> result{};
+  return result; 
+}

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -41,7 +41,7 @@ class wallmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+  void const get_hardware_info(nlohmann::json& j);
 
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -41,7 +41,7 @@ class wallmon final : public Imonitor {
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once
-  void const get_hardware_info(nlohmann::json& j);
+  void const get_hardware_info(nlohmann::json& hw_json);
 
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -40,6 +40,9 @@ class wallmon final : public Imonitor {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
 
+  // This is the hardware information getter that runs once
+  std::map<std::string, std::map<std::string, std::string>> const get_hardware_info();
+
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();
 };


### PR DESCRIPTION
This is still WIP but I think the basic idea is there. Therefore, it might be good to have a discussion before expanding on it.

Now the main interface has a `get_hardware_info()` method that is implemented in each plug-in to collect and return some hardware information. A basic implementation is done in `cpumon` to populate the chip vendor name as well as the number of processors that are defined. 

The collection is off by default and can be enabled w/ an additional argument, `--store-hw-info`, on the `prmon` side.  This results in the creating of a new section in the JSON file, named `HW`, and looks something like this at the moment:

```

  "Avg": {
    "nprocs": 1.0,
    "nthreads": 0.0,
    "pss": 122.0,
    "rchar": 2123.9583333333335,
    "read_bytes": 0.0,
    "rss": 548.0,
    "rx_bytes": 302.6041666666667,
    "rx_packets": 1.5625,
    "swap": 0.0,
    "tx_bytes": 647.1354166666666,
    "tx_packets": 2.6041666666666665,
    "vmem": 4372.0,
    "wchar": 0.0,
    "write_bytes": 0.0 
  },  
  "HW": {
    "cpu": {
      "model name": " Intel(R) Xeon(R) CPU E5-2667 v2 @ 3.30GHz",
      "nCPU": "32"
    }   
  },  
  "Max": {
    "nprocs": 1,
    "nthreads": 0,
    "pss": 122,
    "rchar": 8156,
    "read_bytes": 0,
    "rss": 548,
    "rx_bytes": 1162,
    "rx_packets": 6,
    "stime": 0,
    "swap": 0,
    "tx_bytes": 2485,
    "tx_packets": 10, 
    "utime": 0,
    "vmem": 4372,
    "wchar": 0,
    "write_bytes": 0,
    "wtime": 3
  }
}
```

I think we should have a discussion on what metrics we want to collect for in which plug-ins. The usual `/proc` exposes a number of things that we collect. I personally would like to stay away from using command-line utilities (especially those that require root privileges) but GPU information will possibly be an exception to that.

In any case, this is still a prototype but a decent starting point IMO.

Closes #114.