### PR TITLE
Enable/disable functionality for monitoring components

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The `prmon` binary is invoked with the following arguments:
 ```sh
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
       [--interval 30] [--store-hw-info] [--netdev DEV] \
+      [--monitor ~MON1,MON2,~MON3] \
       [-- prog arg arg ...]
 ```
 
@@ -83,17 +84,24 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
 * `--interval` time, in seconds, between monitoring snapshots
 * `--store-hw-info` flag that turns-on hardware information collection
 * `--netdev` restricts network statistics to one (or more) network devices
+* `--monitor` is used to enable or disable specific monitors: prefixing
+  with `~` disables the monitor, the special `all` name sets the default
+  so, e.g., `--monitor ~all,wallmon,cpumon` would only enable the `wallmon`
+  and `cpumon` monitors (comma separation or multiple specification supported)
+  * Note that the `wallmon` monitor is the only monitor that cannot be disabled
 * `--` after this argument the following arguments are treated as a program to invoke
   and remaining arguments are passed to it; `prmon` will then monitor this process
   instead of being given a PID via `--pid`
 
+When invoked with `-h` or `--help` usage information is printed, as well as a
+list of all available monitoring components.
 
 ## Outputs
 
 In the `filename` output file, plain text with statistics written every
 `interval` seconds are written. The first line gives the column names.
 
-In the `json-summmary` file values for the maximum and average statistics
+In the `json-summary` file values for the maximum and average statistics
 are given in JSON format. This file is rewritten every `interval` seconds
 with the current summary values.
 
@@ -154,4 +162,4 @@ to CMake using `Gperftools_ROOT_DIR`.
 
 # Copyright
 
-Copyright (c) 2018, CERN.
+Copyright (c) 2018-2020, CERN.

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(nlohmann_json REQUIRED)
 
 add_executable(prmon src/prmon.cpp
-					 src/pidutils.cpp
+					 src/prmonutils.cpp
 					 src/netmon.cpp
 					 src/iomon.cpp
 					 src/cpumon.cpp

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -306,7 +306,7 @@ int main(int argc, char* argv[]) {
     else
       std::cerr << "found none";
     std::cerr << std::endl;
-    return 0;
+    return EXIT_FAILURE;
   }
 
   // Extra processing of monitor args

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -57,7 +57,7 @@ void SignalChildHandler(int /*signal*/) {
 
 int MemoryMonitor(const pid_t mpid, const std::string filename,
                   const std::string json_summary_file, const unsigned int interval,
-                  const bool store_hw_info, const std::vector<std::string> netdevs),
+                  const bool store_hw_info, const std::vector<std::string> netdevs,
                   monitor_switch_t monitor_switches) {
   signal(SIGUSR1, SignalCallbackHandler);
   signal(SIGCHLD, SignalChildHandler);

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -25,7 +25,6 @@
 #include "registry.h"
 
 #include "prmonutils.h"
-#include "prmon.h"
 #include "wallmon.h"
 
 bool sigusr1 = false;

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -74,7 +74,12 @@ int MemoryMonitor(const pid_t mpid, const std::string filename,
     // Check if the monitor should be enabled
     bool state{default_state};
     if (monitor_switches.count(class_name) == 1)
-      state = monitor_switches[class_name]; 
+      state = monitor_switches[class_name];
+    // Cannot disable wallmon
+    if (class_name == "wallmon" && state == false) {
+      std::clog << "wallmon monitor cannot be disabled" << std::endl;
+      state = true;
+    }
     if (state) {
       std::unique_ptr<Imonitor> new_monitor_p(registry::Registry<Imonitor>::create(class_name));
       if (new_monitor_p) {
@@ -322,9 +327,6 @@ int main(int argc, char* argv[]) {
 
   // Extra processing of monitor args
   monitor_switch_t monitor_switches = parse_monitor_switches(monitor_args);
-  for (const auto& mon_s: monitor_switches) {
-    std::cout << mon_s.first << " -> " << mon_s.second << std::endl;
-  }
 
   if (got_pid) {
     if (pid < 2) {

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -303,6 +303,7 @@ int main(int argc, char* argv[]) {
         std::cout << " - " << name << " : " << registry::Registry<Imonitor>::get_description(name) << std::endl;
       }
       std::cout << std::endl;
+      std::cout << "More information: https://github.com/HSF/prmon\n" << std::endl;
     return 0;
   }
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -286,7 +286,7 @@ int main(int argc, char* argv[]) {
         << "                          multiple times; default ALL devices)\n"
         << "[--monitor, -m mon]       Enable or disable monitors:\n"
         << "                           ~NAME disables that monitor\n"
-        << "                           +NAME or NAME enables that monitor\n"
+        << "                            NAME enables that monitor\n"
         << "                          comma separation supported or specifing\n"
         << "                          multiple times\n"
         << "                          Special name '[~]all' sets default state\n"

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -201,7 +201,6 @@ int main(int argc, char* argv[]) {
   std::string jsonSummary{default_json_summary};
   std::vector<std::string> netdevs{};
   std::vector<std::string> monitor_args{};
-  std::vector<std::pair<std::string, bool>> monitor_switches;
   unsigned int interval{default_interval};
   bool store_hw_info{default_store_hw_info};
   int do_help{0};
@@ -311,17 +310,9 @@ int main(int argc, char* argv[]) {
   }
 
   // Extra processing of monitor args
-  std::vector<std::pair<std::string, bool>> monitor_switches;
-  for (const auto& mopt : monitor_args) {
-    std::cout << mopt << std::endl;
-    std::string::size_type prev_pos = 0, pos = 0;
-    while((pos = mopt.find(',', pos)) != std::string::npos) {
-      std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // C++17 use string_view
-      prev_pos = ++pos;
-      std::cout << " - " << substring << std::endl; // Process here
-    }
-    std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // Last word
-    std::cout << " - " << substring << std::endl; // Process here
+  monitor_switch_t monitor_switches = parse_monitor_switches(monitor_args);
+  for (const auto& mon_s: monitor_switches) {
+    std::cout << mon_s.first << " -> " << mon_s.second << std::endl;
   }
 
   if (got_pid) {

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -326,7 +326,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Extra processing of monitor args
-  monitor_switch_t monitor_switches = parse_monitor_switches(monitor_args);
+  monitor_switch_t monitor_switches = parse_monitor_switches(monitor_args, true);
 
   if (got_pid) {
     if (pid < 2) {

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -1,9 +1,0 @@
-// Copyright (C) 2020, CERN
-
-#include <sys/types.h>
-#include <vector>
-#include <string>
-
-int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
-                  unsigned int interval, const bool store_hw_info,
-                  const std::vector<std::string> netdevs, monitor_switch_t monitor_switches);

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -6,4 +6,4 @@
 
 int MemoryMonitor(pid_t mpid, char* filename, char* jsonSummary,
                   unsigned int interval, const bool store_hw_info,
-                  const std::vector<std::string> netdevs);
+                  const std::vector<std::string> netdevs, monitor_switch_t monitor_switches);

--- a/package/src/prmon.h
+++ b/package/src/prmon.h
@@ -1,6 +1,4 @@
-/*
-  Copyright (C) 2018, CERN
-*/
+// Copyright (C) 2020, CERN
 
 #include <sys/types.h>
 #include <vector>

--- a/package/src/prmonutils.cpp
+++ b/package/src/prmonutils.cpp
@@ -93,23 +93,23 @@ const monitor_switch_t parse_monitor_switches(const std::vector<std::string> mon
   // Parse a vector of monitor switch strings and decide on the
   // state of each monitor. Each switch string needs to be split
   // on ",", then passed to the "decision" function.
+
   monitor_switch_t monitor_switches{};
-  std::string substring{};
-  std::pair<std::string, bool> switch_tmp_state{};
-  for (const auto& mopt : monitor_args) {
+  for (const auto& mon_opt : monitor_args) {
     std::string::size_type prev_pos = 0, pos = 0;
-    while((pos = mopt.find(',', pos)) != std::string::npos) {
-      std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // C++17 use string_view
+    while((pos = mon_opt.find(',', pos)) != std::string::npos) {
+      // Get substring and pass to interpret function
+      monitor_switches.insert(monitor_switch_state(mon_opt.substr(prev_pos, pos-prev_pos)));
       prev_pos = ++pos;
-      monitor_switches.insert(monitor_switch_state(substring));
     }
-    std::string substring(mopt.substr(prev_pos, pos-prev_pos)); // Last word
-    monitor_switches.insert(monitor_switch_state(substring));
+    // Last word
+    monitor_switches.insert(monitor_switch_state(mon_opt.substr(prev_pos, pos-prev_pos)));
   }
   return monitor_switches;
 }
 
 const std::pair<std::string, bool> monitor_switch_state(const std::string monitor) {
+  // Simple parser to see if the monitor switch has a ~ (meaning off)
   if (monitor[0] == '~') {
     std::pair<std::string, bool> ret{monitor.substr(1, monitor.size()), false};
     return ret;

--- a/package/src/prmonutils.cpp
+++ b/package/src/prmonutils.cpp
@@ -86,3 +86,29 @@ std::vector<pid_t> offspring_pids(const pid_t mother_pid) {
   }
   return pid_list;
 }
+
+
+
+monitor_switch_t parse_monitor_switches(const std::vector<std::string> monitor_args) {
+  monitor_switch_t monitor_switches{};
+  std::string substring{};
+  for (const auto& mopt : monitor_args) {
+    std::cout << mopt << std::endl;
+    std::string::size_type prev_pos = 0, pos = 0;
+    while((pos = mopt.find(',', pos)) != std::string::npos) {
+      std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // C++17 use string_view
+      prev_pos = ++pos;
+      monitor_switches.push_back(monitor_switch_state(substring));
+      std::cout << " - " << substring << std::endl; // Process here
+    }
+    std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // Last word
+    std::cout << " - " << substring << std::endl; // Process here
+  }
+}
+
+bool monitor_switch_state(const std::string monitor) {
+  if (monitor[0] == "~") {
+    return false;
+  }
+  return true;
+}

--- a/package/src/prmonutils.cpp
+++ b/package/src/prmonutils.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <sstream>
 
-#include "pidutils.h"
+#include "prmonutils.h"
 
 bool kernel_proc_pid_test(const pid_t pid) {
   // Return true if the kernel has child PIDs
@@ -89,26 +89,31 @@ std::vector<pid_t> offspring_pids(const pid_t mother_pid) {
 
 
 
-monitor_switch_t parse_monitor_switches(const std::vector<std::string> monitor_args) {
+const monitor_switch_t parse_monitor_switches(const std::vector<std::string> monitor_args) {
+  // Parse a vector of monitor switch strings and decide on the
+  // state of each monitor. Each switch string needs to be split
+  // on ",", then passed to the "decision" function.
   monitor_switch_t monitor_switches{};
   std::string substring{};
+  std::pair<std::string, bool> switch_tmp_state{};
   for (const auto& mopt : monitor_args) {
-    std::cout << mopt << std::endl;
     std::string::size_type prev_pos = 0, pos = 0;
     while((pos = mopt.find(',', pos)) != std::string::npos) {
       std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // C++17 use string_view
       prev_pos = ++pos;
-      monitor_switches.push_back(monitor_switch_state(substring));
-      std::cout << " - " << substring << std::endl; // Process here
+      monitor_switches.insert(monitor_switch_state(substring));
     }
-    std::string substring( mopt.substr(prev_pos, pos-prev_pos) ); // Last word
-    std::cout << " - " << substring << std::endl; // Process here
+    std::string substring(mopt.substr(prev_pos, pos-prev_pos)); // Last word
+    monitor_switches.insert(monitor_switch_state(substring));
   }
+  return monitor_switches;
 }
 
-bool monitor_switch_state(const std::string monitor) {
-  if (monitor[0] == "~") {
-    return false;
+const std::pair<std::string, bool> monitor_switch_state(const std::string monitor) {
+  if (monitor[0] == '~') {
+    std::pair<std::string, bool> ret{monitor.substr(1, monitor.size()), false};
+    return ret;
   }
-  return true;
+  std::pair<std::string, bool> ret{monitor, true};
+  return ret;
 }

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -2,11 +2,14 @@
 #include <unistd.h>
 
 #include <vector>
+#include <utility>
+#include <unordered_map>
 
-using monitor_switch_t = std::vector<std::pair<std::string, bool>>;
+using monitor_switch_t = std::unordered_map<std::string, bool>;
 
 bool kernel_proc_pid_test(const pid_t pid);
 std::vector<pid_t> pstree_pids(const pid_t mother_pid);
 std::vector<pid_t> offspring_pids(const pid_t mother_pid);
 
-monitor_switch_t parse_monitor_switches(std::vector<std::string>);
+const monitor_switch_t parse_monitor_switches(std::vector<std::string>);
+const std::pair<std::string, bool> monitor_switch_state(const std::string monitor);

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -3,6 +3,10 @@
 
 #include <vector>
 
+using monitor_switch_t = std::vector<std::pair<std::string, bool>>;
+
 bool kernel_proc_pid_test(const pid_t pid);
 std::vector<pid_t> pstree_pids(const pid_t mother_pid);
 std::vector<pid_t> offspring_pids(const pid_t mother_pid);
+
+monitor_switch_t parse_monitor_switches(std::vector<std::string>);

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -11,5 +11,5 @@ bool kernel_proc_pid_test(const pid_t pid);
 std::vector<pid_t> pstree_pids(const pid_t mother_pid);
 std::vector<pid_t> offspring_pids(const pid_t mother_pid);
 
-const monitor_switch_t parse_monitor_switches(std::vector<std::string>);
+const monitor_switch_t parse_monitor_switches(std::vector<std::string>, bool);
 const std::pair<std::string, bool> monitor_switch_state(const std::string monitor);


### PR DESCRIPTION
Closes #107 

~~This PR builds off #115, so it's WIP until that is accepted.~~ However, it's essentially ready to go in its own right.

A new switch, `-m/--monitor`, is added that allows monitoring components to be enabled or disabled. The switch can be given multiple times and allows for a comma separated list of monitors to be given. If the name of the monitor is given the component is enabled. If the name is prefixed with `~` then it is disabled. The special name `all` sets the default status (useful when given as `~all` that switches all components off by default).

The `wallmon` component cannot be disabled as it's needed by the main monitor loop.

| switch | effect |
|----|----|
| `-m ~netmon` | disable network monitoring |
| `-m ~netmon,~iomon` | disable network and io monitoring |
| `-m ~netmon -m ~iomon` | disable network and io monitoring |
| `-m ~all,memmon,cpumon` | only enable memory and cpu monitoring |
| `-m ~all -m memmon,cpumon` | only enable memory and cpu monitoring |

As part of this PR `pidutils.cpp` is renamed to `prmonutils.cpp` as it now contains generally utilities for the main prmon code (cf. `utils.cpp` which is for the monitors).