### PR TITLE
Remove the offset in nthreads

### DIFF
--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -38,7 +38,7 @@ void countmon::update_stats(const std::vector<pid_t>& pids) {
     }
     if (stat_entries.size() > prmon::stat_count_read_limit) {
       count_stats["nprocs"]   += 1L;
-      count_stats["nthreads"] += std::stol(stat_entries[prmon::num_threads]) - 1L;
+      count_stats["nthreads"] += std::stol(stat_entries[prmon::num_threads]);
     }
     stat_entries.clear();
   }

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -162,8 +162,11 @@ int main(int argc, char* argv[]) {
 
   // Each process runs the requested number of threads
   std::vector<std::thread> pool;
-  for (unsigned int i = 0; i < threads; ++i)
+  for (unsigned int i = 1; i < threads; ++i)
     pool.push_back(std::thread(burn_for, runtime * std::kilo::num * (pid ? 1.0 : child_runtime_fraction)));
+  
+  // We also burn CPU in the mother thread
+  burn_for(runtime * std::kilo::num * (pid ? 1.0 : child_runtime_fraction));
 
   for (auto& th : pool) th.join();
 

--- a/package/tests/testCOUNT.py
+++ b/package/tests/testCOUNT.py
@@ -45,7 +45,7 @@ def setupConfigurableTest(threads=1, procs=1, time=10.0, interval=1, invoke=Fals
                 totPROC      = prmonJSON["Max"]["nprocs"] 
                 totTHREAD    = prmonJSON["Max"]["nthreads"]
                 expectPROC   = procs
-                expectTHREAD = procs*threads 
+                expectTHREAD = procs*(threads+1)
                 self.assertAlmostEqual(totPROC, expectPROC, msg = "Inconsistent value for number of processes "
                              "(expected {0}, got {1})".format(expectPROC, totPROC))
                 self.assertAlmostEqual(totTHREAD, expectTHREAD, msg = "Inconsistent value for number of total threads "

--- a/package/tests/testCOUNT.py
+++ b/package/tests/testCOUNT.py
@@ -45,7 +45,7 @@ def setupConfigurableTest(threads=1, procs=1, time=10.0, interval=1, invoke=Fals
                 totPROC      = prmonJSON["Max"]["nprocs"] 
                 totTHREAD    = prmonJSON["Max"]["nthreads"]
                 expectPROC   = procs
-                expectTHREAD = procs*(threads+1)
+                expectTHREAD = procs*threads
                 self.assertAlmostEqual(totPROC, expectPROC, msg = "Inconsistent value for number of processes "
                              "(expected {0}, got {1})".format(expectPROC, totPROC))
                 self.assertAlmostEqual(totTHREAD, expectTHREAD, msg = "Inconsistent value for number of total threads "


### PR DESCRIPTION
As discussed in #121, for each process we were subtracting 1 from `nthreads` to offset the mother thread from accounting. Although there is no loss of information, this might be confusing and is against the common pattern of simply reporting what we measure. Therefore, this PR gets rid of it. The test script is also updated to take this change into account.

Closes #121.