### PR TITLE
Add NVIDIA GPU monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.3)
 # - Call project() to setup system
 # From CMake 3, we can set the project version easily in one go
-project(prmon VERSION 1.1.1)
+project(prmon VERSION 1.2.0)
 
 #--- Define basic build settings -----------------------------------------------
 # - Use GNU-style hierarchy for installing build products

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -3,12 +3,12 @@ find_package(nlohmann_json REQUIRED)
 add_executable(prmon src/prmon.cpp
            src/prmonutils.cpp
            src/utils.cpp
-					 src/netmon.cpp
-					 src/iomon.cpp
-					 src/cpumon.cpp
-					 src/countmon.cpp
-					 src/wallmon.cpp
-					 src/memmon.cpp
+           src/netmon.cpp
+           src/iomon.cpp
+           src/cpumon.cpp
+           src/countmon.cpp
+           src/wallmon.cpp
+           src/memmon.cpp
            src/nvidiamon.cpp
            )
 

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -3,7 +3,6 @@ find_package(nlohmann_json REQUIRED)
 add_executable(prmon src/prmon.cpp
            src/prmonutils.cpp
            src/utils.cpp
-					 src/prmonutils.cpp
 					 src/netmon.cpp
 					 src/iomon.cpp
 					 src/cpumon.cpp

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -3,12 +3,15 @@ find_package(nlohmann_json REQUIRED)
 add_executable(prmon src/prmon.cpp
            src/prmonutils.cpp
            src/utils.cpp
-           src/netmon.cpp
-           src/iomon.cpp
-           src/cpumon.cpp
-           src/countmon.cpp
-           src/wallmon.cpp
-           src/memmon.cpp)
+					 src/prmonutils.cpp
+					 src/netmon.cpp
+					 src/iomon.cpp
+					 src/cpumon.cpp
+					 src/countmon.cpp
+					 src/wallmon.cpp
+					 src/memmon.cpp
+           src/nvidiamon.cpp
+           )
 
 # Some older versions of the nlohmann_json package don't define
 # this target (< 3.0.0 ?). The build on these platforms seems to

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -31,7 +31,6 @@ class Imonitor {
 
   virtual void const get_hardware_info(nlohmann::json& hw_json) = 0;
   virtual bool const is_valid() = 0;
-
 };
 
 #endif  // PRMON_IMONITOR_H

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -30,6 +30,8 @@ class Imonitor {
       unsigned long long elapsed_clock_ticks) = 0;
 
   virtual void const get_hardware_info(nlohmann::json& hw_json) = 0;
+  virtual bool const is_valid() = 0;
+
 };
 
 #endif  // PRMON_IMONITOR_H

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -42,6 +42,8 @@ class countmon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
+  bool const is_valid() {return true;}
+
 };
 REGISTER_MONITOR(Imonitor, countmon, "Monitor number of processes and threads")
 

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -42,8 +42,7 @@ class countmon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
-  bool const is_valid() {return true;}
-
+  bool const is_valid() { return true; }
 };
 REGISTER_MONITOR(Imonitor, countmon, "Monitor number of processes and threads")
 

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -36,6 +36,8 @@ class cpumon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
+  bool const is_valid() {return true;}
+
 };
 REGISTER_MONITOR(Imonitor, cpumon, "Monitor cpu time used")
 

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -36,8 +36,7 @@ class cpumon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
-  bool const is_valid() {return true;}
-
+  bool const is_valid() { return true; }
 };
 REGISTER_MONITOR(Imonitor, cpumon, "Monitor cpu time used")
 

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -35,6 +35,8 @@ class iomon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
+  bool const is_valid() {return true;}
+
 };
 REGISTER_MONITOR(Imonitor, iomon, "Monitor input and output activity")
 

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -35,8 +35,7 @@ class iomon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
-  bool const is_valid() {return true;}
-
+  bool const is_valid() { return true; }
 };
 REGISTER_MONITOR(Imonitor, iomon, "Monitor input and output activity")
 

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -41,8 +41,7 @@ class memmon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
-  bool const is_valid() {return true;}
-
+  bool const is_valid() { return true; }
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")
 

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -41,6 +41,8 @@ class memmon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
+  bool const is_valid() {return true;}
+
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")
 

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -71,8 +71,7 @@ class netmon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
-  bool const is_valid() {return true;}
-
+  bool const is_valid() { return true; }
 };
 REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")
 

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -71,6 +71,8 @@ class netmon final : public Imonitor {
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);
+  bool const is_valid() {return true;}
+
 };
 REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")
 

--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -1,0 +1,194 @@
+// Copyright (C) CERN, 2020
+
+#include "nvidiamon.h"
+#include "utils.h"
+
+#include <string>
+#include <iostream>
+#include <sstream>
+
+#include <unistd.h>
+#include <stdlib.h>
+
+// This is not very nice, but we don't want to add more special runtime
+// flags, pending a proper decision on logging (#106)
+#define NVIDIA_DEBUG 0
+
+// Constructor; uses RAII pattern to be valid after construction
+nvidiamon::nvidiamon() : nvidia_params{prmon::default_nvidia_params},  
+  nvidia_stats{}, nvidia_average_stats{}, nvidia_total_stats{}, iterations{0L} {
+  for (const auto& nvidia_param : nvidia_params) { 
+    nvidia_stats[nvidia_param] = 0;
+    nvidia_peak_stats[nvidia_param] = 0;
+    nvidia_average_stats[nvidia_param] = 0;
+    nvidia_total_stats[nvidia_param] = 0;
+  }
+
+  // Attempt to execute nvidia-smi
+  // If this works we are valid, but if not then we can't get data
+  valid = test_nvidia_smi();
+}
+
+void nvidiamon::update_stats(const std::vector<pid_t>& pids) {
+  const std::vector<std::string> cmd = {"nvidia-smi", "pmon", "-s", "um", "-c", "1"};
+
+  for (auto& stat : nvidia_stats) stat.second = 0;
+
+  auto cmd_result = prmon::cmd_pipe_output(cmd);
+  if (cmd_result.first) {
+    // Failed
+    return;
+  }
+
+  if (NVIDIA_DEBUG) {
+    std::cout << "nvidiamon::update_stats got the following output (" << cmd_result.second.size() << "): " << std::endl;
+    int i = 0;
+    for (const auto& s : cmd_result.second) {
+      std::cout << i << " -> " << s << std::endl;
+      ++i;
+    }
+  }
+
+  // Loop over output
+  unsigned int gpu_idx, sm, mem, enc, dec, fb_mem;
+  pid_t pid;
+  std::string cg_type, cmd_name;
+  std::vector<unsigned int> activegpus{}; // Avoid double counting active GPUs
+  for (const auto& s : cmd_result.second) {
+    if (s[0] != '#') {
+      std::istringstream instr(s);
+      instr >> gpu_idx >> pid >> cg_type >> sm >> mem >> enc >> dec >> fb_mem >> cmd_name;
+      if (!(instr.fail() || instr.bad())) {
+        if (NVIDIA_DEBUG) {
+          std::cout << "Good read: " << gpu_idx << " " << pid << " " << 
+            cg_type << " " << sm << " " << mem << " " << enc << " " << 
+            dec << " " << fb_mem << " " << cmd_name << std::endl;
+        }
+
+        // Filter on PID value, so we only add stats for our processes
+        for (auto const p : pids) {
+          if (p == pid) {
+            nvidia_stats["gpusmpct"] += sm;
+            nvidia_stats["gpumempct"] += mem;
+            nvidia_stats["gpufbmem"] += fb_mem;
+            bool new_gpu = true;
+            for (auto const gpu : activegpus) {
+              if (gpu == gpu_idx) new_gpu = false;
+            }
+            if (new_gpu) {
+              activegpus.push_back(gpu_idx);
+              ++nvidia_stats["ngpus"];
+            }
+          }
+        }
+      } else if (NVIDIA_DEBUG) {
+        std::clog << "Bad read of line: " << s << std::endl;
+        std::cout << "Parsed to: " << gpu_idx << " " << pid << " " << 
+          cg_type << " " << sm << " " << mem << " " << enc << " " << 
+          dec << " " << fb_mem << " " << cmd_name << std::endl;
+        std::cout << " good()=" << instr.good();
+        std::cout << " eof()=" << instr.eof();
+        std::cout << " fail()=" << instr.fail();
+        std::cout << " bad()=" << instr.bad() << std::endl;
+      }
+    }
+  }
+
+  if (NVIDIA_DEBUG) {
+    std::cout << "Parsed: " << nvidia_stats["ngpus"] << " " << nvidia_stats["gpusmpct"] <<
+      " " << nvidia_stats["gpumempct"] <<
+      " " << nvidia_stats["gpufbmem"] << std::endl;
+  }
+
+  // Update the statistics with the new snapshot values
+  ++iterations;
+  for(const auto& nvidia_param : nvidia_params) {
+    if(nvidia_stats[nvidia_param] > nvidia_peak_stats[nvidia_param]) {
+      nvidia_peak_stats[nvidia_param] = nvidia_stats[nvidia_param];
+    }
+    nvidia_total_stats[nvidia_param] += nvidia_stats[nvidia_param];
+    nvidia_average_stats[nvidia_param] = double(nvidia_total_stats[nvidia_param]) / iterations;
+  }
+}
+
+// Return the nvidiaers
+std::map<std::string, unsigned long long> const nvidiamon::get_text_stats() {
+  return nvidia_stats;
+}
+
+// For JSON return the peaks
+std::map<std::string, unsigned long long> const nvidiamon::get_json_total_stats() {
+  return nvidia_peak_stats;
+}
+
+// An the averages 
+std::map<std::string, double> const nvidiamon::get_json_average_stats(
+    unsigned long long elapsed_clock_ticks) {
+  return nvidia_average_stats;
+}
+
+bool nvidiamon::test_nvidia_smi() {
+  const std::vector<std::string> cmd = {"nvidia-smi", "-L"};
+
+  // The use of execvp means searching along PATH, which is fine
+  // but does imply some extra stat() calls; nvidia-smi isn't going
+  // to change location, so there is an argument for finding and
+  // caching the directory path
+  auto cmd_result = prmon::cmd_pipe_output(cmd);
+  if (cmd_result.first != 0) return false;
+  unsigned int gpus = 0;
+  for (auto const& s: cmd_result.second) {
+    // From C++20 can use 'starts_with'
+    if (s.substr(0, 3).compare("GPU") == 0) {
+      ++gpus;
+    }
+  }
+  nvidiamon::ngpus = gpus;
+  if (gpus == 0) {
+    std::clog << "Executed 'nvidia-smi -L', but no GPUs found" << std::endl;
+    return false;
+  } else if (gpus > 4) {
+    std::clog << "More than 4 GPUs found, so GPU process monitoring will be unreliable" << std::endl;
+  }
+  return true;
+}
+
+
+// Collect related hardware information
+void const nvidiamon::get_hardware_info(nlohmann::json& hw_json) {
+  // Record the number of GPUs
+  hw_json["HW"]["gpu"]["nGPU"] = nvidiamon::ngpus;
+
+  // For the GPUs present we get details using "nvidia-smi --query-gpu="
+  // Note that the name is put at the end of the output as it makes
+  // parsing easier
+  std::vector<std::string> cmd = {"nvidia-smi", "--query-gpu=clocks.max.sm,memory.total,gpu_name", "--format=csv,noheader,nounits"};
+  auto cmd_result = prmon::cmd_pipe_output(cmd);
+  if (cmd_result.first) {
+    std::cerr << "Failed to get hardware details for GPUs" << std::endl;
+    return;
+  }
+  unsigned int sm_freq, total_mem;
+  unsigned int count{0};
+  for (auto const& s: cmd_result.second) {
+    std::istringstream instr(s);
+    instr >> sm_freq;
+    instr.get(); // Swallow the comma
+    instr >> total_mem;
+    auto pos = std::string::size_type(instr.tellg()) + 2; // Skip ", "
+    std::string name{"unknown"};
+    if (pos <= s.size()) { // This should never fail, but...
+      name = s.substr(pos);
+    }
+    if (!(instr.fail() || instr.bad())) {
+      std::string gpu_number = "gpu_" + std::to_string(count);
+      hw_json["HW"]["gpu"][gpu_number]["name"] = name;
+      hw_json["HW"]["gpu"][gpu_number]["sm_freq"] = sm_freq;
+      hw_json["HW"]["gpu"][gpu_number]["total_mem"] = total_mem * 1024; // To kB
+    } else {
+      std::clog << "Unexpected line from GPU hardware query: " << s << std::endl;
+    }
+    ++count;
+  }
+  return;
+}

--- a/package/src/nvidiamon.h
+++ b/package/src/nvidiamon.h
@@ -36,6 +36,10 @@ class nvidiamon final : public Imonitor {
   // Test if nvidia-smi is available
   bool test_nvidia_smi();
 
+  // Conversion from MB to kB for (this is to be more consistent with other
+  // memory units in prmon)
+  const unsigned int MB_to_KB = 1024;
+
  public:
   nvidiamon();
 

--- a/package/src/nvidiamon.h
+++ b/package/src/nvidiamon.h
@@ -1,0 +1,58 @@
+// Copyright (C) CERN, 2020
+//
+// Process and thread number monitoring class
+//
+
+#ifndef PRMON_NVIDIAMON_H
+#define PRMON_NVIDIAMON_H 1
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "Imonitor.h"
+#include "registry.h"
+
+class nvidiamon final : public Imonitor {
+ private:
+  // Which paramters to measure and output key names
+  std::vector<std::string> nvidia_params;
+
+  // Container for total stats
+  std::map<std::string, unsigned long long> nvidia_stats;
+  std::map<std::string, unsigned long long> nvidia_peak_stats;
+  std::map<std::string, double> nvidia_average_stats;
+  std::map<std::string, unsigned long long> nvidia_total_stats;
+
+  // Counter for number of iterations
+  unsigned long iterations;
+
+  // Set a boolean to see if we have a valid nvidia setup
+  bool valid;
+
+  // Count GPUs on the system
+  unsigned int ngpus;
+
+  // Test if nvidia-smi is available
+  bool test_nvidia_smi();
+
+ public:
+  nvidiamon();
+
+  void update_stats(const std::vector<pid_t>& pids);
+
+  // These are the stat getter methods which retrieve current statistics
+  std::map<std::string, unsigned long long> const get_text_stats();
+  std::map<std::string, unsigned long long> const get_json_total_stats();
+  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+
+  void const get_hardware_info(nlohmann::json& hw_json);
+  
+  bool const is_valid() {
+    return valid;
+  }
+
+};
+REGISTER_MONITOR(Imonitor, nvidiamon, "Monitor NVIDIA GPU activity")
+
+#endif  // PRMON_NVIDIAMON_H

--- a/package/src/nvidiamon.h
+++ b/package/src/nvidiamon.h
@@ -6,8 +6,8 @@
 #ifndef PRMON_NVIDIAMON_H
 #define PRMON_NVIDIAMON_H 1
 
-#include <string>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "Imonitor.h"
@@ -44,14 +44,12 @@ class nvidiamon final : public Imonitor {
   // These are the stat getter methods which retrieve current statistics
   std::map<std::string, unsigned long long> const get_text_stats();
   std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(unsigned long long elapsed_clock_ticks);
+  std::map<std::string, double> const get_json_average_stats(
+      unsigned long long elapsed_clock_ticks);
 
   void const get_hardware_info(nlohmann::json& hw_json);
-  
-  bool const is_valid() {
-    return valid;
-  }
 
+  bool const is_valid() { return valid; }
 };
 REGISTER_MONITOR(Imonitor, nvidiamon, "Monitor NVIDIA GPU activity")
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -42,7 +42,9 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
     std::unique_ptr<Imonitor> new_monitor_p(
         registry::Registry<Imonitor>::create(class_name));
     if (new_monitor_p) {
-      monitors[class_name] = std::move(new_monitor_p);
+      if (new_monitor_p->is_valid()) {
+        monitors[class_name] = std::move(new_monitor_p);
+      }
     } else {
       std::cerr << "Registration of monitor " << class_name << " FAILED"
                 << std::endl;

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -29,9 +29,9 @@
 bool prmon::sigusr1 = false;
 
 int ProcessMonitor(const pid_t mpid, const std::string filename,
-                  const std::string json_summary_file,
-                  const unsigned int interval, const bool store_hw_info,
-                  const std::vector<std::string> netdevs) {
+                   const std::string json_summary_file,
+                   const unsigned int interval, const bool store_hw_info,
+                   const std::vector<std::string> netdevs) {
   signal(SIGUSR1, prmon::SignalCallbackHandler);
 
   // This is the vector of all monitoring components
@@ -290,7 +290,8 @@ int main(int argc, char* argv[]) {
       std::cerr << "Bad PID to monitor.\n";
       return 1;
     }
-    ProcessMonitor(pid, filename, jsonSummary, interval, store_hw_info, netdevs);
+    ProcessMonitor(pid, filename, jsonSummary, interval, store_hw_info,
+                   netdevs);
   } else {
     if (child_args == argc) {
       std::cerr << "Found marker for child program to execute, but with no "
@@ -302,7 +303,7 @@ int main(int argc, char* argv[]) {
       execvp(argv[child_args], &argv[child_args]);
     } else if (child > 0) {
       ProcessMonitor(child, filename, jsonSummary, interval, store_hw_info,
-                    netdevs);
+                     netdevs);
     }
   }
 

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -7,14 +7,11 @@
 #ifndef PRMON_UTILS_H
 #define PRMON_UTILS_H 1
 
-#include <vector>
+#include <signal.h>
+#include <unistd.h>
+
 #include <string>
 #include <utility>
-
-#include <unistd.h>
-#include <signal.h>
-
-#include <string>
 #include <vector>
 
 namespace prmon {
@@ -40,8 +37,8 @@ const static std::vector<std::string> default_io_params{
     "rchar", "wchar", "read_bytes", "write_bytes"};
 const static std::vector<std::string> default_count_params{"nprocs",
                                                            "nthreads"};
-const static std::vector<std::string> default_nvidia_params{"ngpus", "gpusmpct", 
-                                                            "gpumempct", "gpufbmem"};
+const static std::vector<std::string> default_nvidia_params{
+    "ngpus", "gpusmpct", "gpumempct", "gpufbmem"};
 
 // This is a utility function that executes a command and
 // pipes the output back, returning a vector of strings

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -7,7 +7,12 @@
 #ifndef PRMON_UTILS_H
 #define PRMON_UTILS_H 1
 
+#include <vector>
+#include <string>
+#include <utility>
+
 #include <unistd.h>
+#include <signal.h>
 
 #include <string>
 #include <vector>
@@ -35,6 +40,8 @@ const static std::vector<std::string> default_io_params{
     "rchar", "wchar", "read_bytes", "write_bytes"};
 const static std::vector<std::string> default_count_params{"nprocs",
                                                            "nthreads"};
+const static std::vector<std::string> default_nvidia_params{"ngpus", "gpusmpct", 
+                                                            "gpumempct", "gpufbmem"};
 
 // This is a utility function that executes a command and
 // pipes the output back, returning a vector of strings

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -46,6 +46,8 @@ class wallmon final : public Imonitor {
 
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();
+
+  bool const is_valid() {return true;}
 };
 REGISTER_MONITOR(Imonitor, wallmon, "Monitor wallclock time")
 

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -47,7 +47,7 @@ class wallmon final : public Imonitor {
   // Class specific method to retrieve wallclock time in clock ticks
   unsigned long long const get_wallclock_clock_t();
 
-  bool const is_valid() {return true;}
+  bool const is_valid() { return true; }
 };
 REGISTER_MONITOR(Imonitor, wallmon, "Monitor wallclock time")
 


### PR DESCRIPTION
Closes #105 

This code adds a monitor for NVIDA GPUs to prmon. When prmon starts it tries to invoke `nvidia-smi` to see if there are relevant GPUs to monitor. If it finds any then monitoring is enabled.

The statistics printed are:

- `gpusmpct` - sum of the streaming multiprocessor usage from this job as a %age value (thus 89 means 89% use, and so on; can be >100% when multiple GPUs are active)
- `gpumempct` - sum of the memory bandwidth used from this job as a %age value
- `gpufbmem` - sum of fb memory, in **kB**
- `ngpus` - number of GPUs actively used by this job

The list of processes from the monitored job is used to ensure that statistics are only gathered for this job family (so if other users are utilising the GPU, this is ignored).

If hardware statistics (`--store-hw-info`) are requested then the following will be reported:

```
        "gpu": {
            "gpu_0": {
                "name": "TITAN Xp",
                "sm_freq": 1911,
                "total_mem": 12488704
            },
            "gpu_1": {
                "name": "TITAN Xp",
                "sm_freq": 1911,
                "total_mem": 12487680
            },
            "nGPU": 2
        },
```

i.e., the total number of GPUs found, then for each GPU the model name, the clock frequency of the streaming multiprocessors (MHz) and the total amount of memory (kB).

There are some general utility enhancements included in this PR:

1. A new utility function, `cmd_pipe_output` is added (helper for running external commands)
1. `prmon` no longer sets a general `SIGCHLD` handler, as it is fragile when being used in combination with forked children in `cmd_pipe_output`
    1. The main `prmon` loop simply reaps child processes' exit codes every cycle

As the `nvidiamon` code needs to check if it has valid things to monitor, an `is_valid()` method is added to the `Imonitor` virtual base class. All other monitors simple return `true`.

