### PR TITLE
Omit running clang-format for pushes into master/stable

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,11 +1,11 @@
 # Name of the workflow
 name: Clang-Format
 
-# Controls when the action will run. Triggers the workflow on push for
-# the master and stable branches
+# Controls when the action will run. Triggers the workflow on push
+# except for the master and stable branches
 on:
   push:
-    branches: [ master, stable ]
+    branches-ignore: [ master, stable ]
 
 # Defines the main job where we checkout our code, run clang-format
 # and commit changes

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -15,7 +15,8 @@
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-cpumon::cpumon() : cpu_params{prmon::default_cpu_params}, cpu_stats{} { for (const auto& cpu_param : cpu_params) cpu_stats[cpu_param] = 0;
+cpumon::cpumon() : cpu_params{prmon::default_cpu_params}, cpu_stats{} {
+  for (const auto& cpu_param : cpu_params) cpu_stats[cpu_param] = 0;
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {


### PR DESCRIPTION
With #133 it became obvious that the logic that we discussed in #131 doesn't work because `master` branch is protected according to our settings. Loosening the requirements will resolve this but I don't think we want to do that just for this.

This PR is proposing to change how we run `clang-format`. Now, we run it for all pushes except for the `master` and `stable` branches. So, when a new branch is pushed to the repository, `clang-format` will run automatically and amend the branch if necessary, as it just happened at:

https://github.com/HSF/prmon/runs/780586384?check_suite_focus=true

Then any consecutive push will trigger `clang-format` and fix issues as they appear. One has to be careful and `pull` the changes locally iff `clang-format` actually updated branch. I don't think this is the end of the world but let me know what you think @graeme-a-stewart.