### PR TITLE
Arm fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set the compiler to be more picky
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -Werror")
+string(REGEX MATCH "^arm" ARM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+if("${ARM_PROCESSOR}" STREQUAL "arm")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
+  message(STATUS "Disabled ABI warnings on ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+endif()
+
 
 # Add package utilities to CMake path
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -106,10 +106,8 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
   // installed nCPU = nSockets * nSiblings nSiblings = nCoresPerSocket *
   // nThreadsPerCore
   // Next 4 lines are a workaround for Raspberry Pi
-  if (!nSiblings)
-    nSiblings = nCPU;
-  if (!nCores)
-    nCores = nCPU;
+  if (!nSiblings) nSiblings = nCPU;
+  if (!nCores) nCores = nCPU;
   unsigned int nSockets = nCPU / nSiblings;
   unsigned int nThreads = nSiblings / nCores;
   hw_json["HW"]["cpu"]["nCPU"] = nCPU;

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -105,6 +105,11 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
   // The clear assumption here is that there is a single type of processor
   // installed nCPU = nSockets * nSiblings nSiblings = nCoresPerSocket *
   // nThreadsPerCore
+  // Next 4 lines are a workaround for Raspberry Pi
+  if (!nSiblings)
+    nSiblings = nCPU;
+  if (!nCores)
+    nCores = nCPU;
   unsigned int nSockets = nCPU / nSiblings;
   unsigned int nThreads = nSiblings / nCores;
   hw_json["HW"]["cpu"]["nCPU"] = nCPU;

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -30,7 +30,7 @@ bool prmon::sigusr1 = false;
 
 int ProcessMonitor(const pid_t mpid, const std::string filename,
                    const std::string json_summary_file,
-                   const unsigned int interval, const bool store_hw_info,
+                   const time_t interval, const bool store_hw_info,
                    const std::vector<std::string> netdevs) {
   signal(SIGUSR1, prmon::SignalCallbackHandler);
 
@@ -197,10 +197,10 @@ int main(int argc, char* argv[]) {
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
 
-  char c;
+  int c;
   while ((c = getopt_long(argc, argv, "p:f:j:i:sn:h", long_options, NULL)) !=
          -1) {
-    switch (c) {
+    switch (char(c)) {
       case 'p':
         pid = std::stoi(optarg);
         got_pid = true;

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -29,8 +29,8 @@
 bool prmon::sigusr1 = false;
 
 int ProcessMonitor(const pid_t mpid, const std::string filename,
-                   const std::string json_summary_file,
-                   const time_t interval, const bool store_hw_info,
+                   const std::string json_summary_file, const time_t interval,
+                   const bool store_hw_info,
                    const std::vector<std::string> netdevs) {
   signal(SIGUSR1, prmon::SignalCallbackHandler);
 

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -68,9 +68,9 @@ int main(int argc, char* argv[]) {
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
 
-  char c;
+  int c;
   while ((c = getopt_long(argc, argv, "t:p:c:r:h", long_options, NULL)) != -1) {
-    switch (c) {
+    switch (char(c)) {
       case 't':
         if (std::stoi(optarg) < 0) {
           std::cerr << "threads parameter must be greater than or equal to 0 "

--- a/package/tests/io-burner.cpp
+++ b/package/tests/io-burner.cpp
@@ -90,10 +90,10 @@ int main(int argc, char* argv[]) {
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
 
-  char c;
+  int c;
   while ((c = getopt_long(argc, argv, "i:t:p:u:s:h", long_options, NULL)) !=
          -1) {
-    switch (c) {
+    switch (char(c)) {
       case 'i':
         if (std::stol(optarg) < 1) {
           std::cerr << "IO parameter must be greater than 0 (--help for usage)"

--- a/package/tests/mem-burner.cpp
+++ b/package/tests/mem-burner.cpp
@@ -41,9 +41,9 @@ int main(int argc, char* argv[]) {
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
 
-  char c;
+  int c;
   while ((c = getopt_long(argc, argv, "m:f:s:p:h", long_options, NULL)) != -1) {
-    switch (c) {
+    switch (char(c)) {
       case 'm':
         if (std::stol(optarg) < 0) {
           std::cerr << "malloc (MB) must be greater than 0 (--help for usage)"


### PR DESCRIPTION
Fixes #135.

- Suppress very noisy ABI warnings (originally due to a gcc5 bug on ARM systems, that was fixed in gcc7)
- Fix the parsing of options on systems where `char` is unsigned.
  - Also make `interval` a `time_t`, to make comparisons with `time(0)` more robust (again, a signed/unsigned issue on ARM platforms)
- Workaround for getting CPU hardware information on ARM (pending more robust fix in #136)

Once #136 is fixed this PR will be updated