### PR TITLE
Get the CPU information from lscpu

### DIFF
--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -112,9 +112,9 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     // Fill the JSON with the information
     if (metricToName.count(key) == 1) {
       if (isNumber(value))
-        hw_json["HW"]["cpu"][key] = std::stoi(value);
+        hw_json["HW"]["cpu"][metricToName.at(key)] = std::stoi(value);
       else
-        hw_json["HW"]["cpu"][key] = value;
+        hw_json["HW"]["cpu"][metricToName.at(key)] = value;
     }
   }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -75,15 +75,15 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     return;
   }
 
-  // Metrics that'll be kept from the lscpu output 
-  const std::vector<std::string> metrics{"Model name",  "Socket(s)", 
-    "Core(s) per socket", "Thread(s) per core"};
+  // Metrics that'll be kept from the lscpu output
+  const std::vector<std::string> metrics{
+      "Model name", "Socket(s)", "Core(s) per socket", "Thread(s) per core"};
 
   // Useful function to determine if a string is purely a number
-  auto isNumber = [] (const std::string& s) 
-  {
-    return !s.empty() && std::find_if(s.begin(), 
-          s.end(), [](unsigned char c) { return !std::isdigit(c); }) == s.end();
+  auto isNumber = [](const std::string& s) {
+    return !s.empty() && std::find_if(s.begin(), s.end(), [](unsigned char c) {
+                           return !std::isdigit(c);
+                         }) == s.end();
   };
 
   // Loop over the output, parse the line, check the key and store the value if
@@ -91,7 +91,6 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
   std::string key{}, value{};
 
   for (const auto& line : cmd_result.second) {
-
     // Continue on empty line
     if (line.empty()) continue;
 
@@ -101,16 +100,18 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
 
     // Read "key":"value" pairs
     key = line.substr(0, splitIdx);
-    value = line.substr(splitIdx+1);
-    if ( key.empty() || value.empty() ) continue;
+    value = line.substr(splitIdx + 1);
+    if (key.empty() || value.empty()) continue;
     key = std::regex_replace(key, std::regex("^\\s+|\\s+$"), "");
     value = std::regex_replace(value, std::regex("^\\s+|\\s+$"), "");
 
     // Fill the JSON with the information
     for (const auto& metric : metrics) {
-      if ( key.compare(metric) != 0 ) continue;
-      if ( isNumber(value) ) hw_json["HW"]["cpu"][key] = std::stoi(value);
-      else hw_json["HW"]["cpu"][key] = value;
+      if (key.compare(metric) != 0) continue;
+      if (isNumber(value))
+        hw_json["HW"]["cpu"][key] = std::stoi(value);
+      else
+        hw_json["HW"]["cpu"][key] = value;
     }
   }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -75,9 +75,13 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     return;
   }
 
-  // Metrics that'll be kept from the lscpu output
-  const std::vector<std::string> metrics{
-      "Model name", "Socket(s)", "Core(s) per socket", "Thread(s) per core"};
+  // Map lscpu names to the desired ones in the JSON
+  const std::map<std::string, std::string> prettyNames{
+      {"Model name", "ModelName"},
+      {"CPU(s)", "CPUs"},
+      {"Socket(s)", "Sockets"},
+      {"Core(s) per socket", "CoresPerSocket"},
+      {"Thread(s) per core", "ThreadsPerCore"}};
 
   // Useful function to determine if a string is purely a number
   auto isNumber = [](const std::string& s) {
@@ -106,12 +110,12 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     value = std::regex_replace(value, std::regex("^\\s+|\\s+$"), "");
 
     // Fill the JSON with the information
-    for (const auto& metric : metrics) {
-      if (key.compare(metric) != 0) continue;
+    if (key == "Model name" || key == "CPU(s)" || key == "Socket(s)" ||
+        key == "Core(s) per socket" || key == "Thread(s) per core") {
       if (isNumber(value))
-        hw_json["HW"]["cpu"][key] = std::stoi(value);
+        hw_json["HW"]["cpu"][prettyNames.at(key)] = std::stoi(value);
       else
-        hw_json["HW"]["cpu"][key] = value;
+        hw_json["HW"]["cpu"][prettyNames.at(key)] = value;
     }
   }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -76,7 +76,7 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
   }
 
   // Map lscpu names to the desired ones in the JSON
-  const std::map<std::string, std::string> prettyNames{
+  const std::map<std::string, std::string> metricToName{
       {"Model name", "ModelName"},
       {"CPU(s)", "CPUs"},
       {"Socket(s)", "Sockets"},
@@ -110,12 +110,13 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     value = std::regex_replace(value, std::regex("^\\s+|\\s+$"), "");
 
     // Fill the JSON with the information
-    if (key == "Model name" || key == "CPU(s)" || key == "Socket(s)" ||
-        key == "Core(s) per socket" || key == "Thread(s) per core") {
+    for (const auto& metric : metricToName) {
+      if (key != metric.first) continue;
       if (isNumber(value))
-        hw_json["HW"]["cpu"][prettyNames.at(key)] = std::stoi(value);
+        hw_json["HW"]["cpu"][metricToName.at(key)] = std::stoi(value);
       else
-        hw_json["HW"]["cpu"][prettyNames.at(key)] = value;
+        hw_json["HW"]["cpu"][metricToName.at(key)] = value;
+      break;
     }
   }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -113,9 +113,9 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     for (const auto& metric : metricToName) {
       if (key != metric.first) continue;
       if (isNumber(value))
-        hw_json["HW"]["cpu"][metricToName.at(key)] = std::stoi(value);
+        hw_json["HW"]["cpu"][metric.second] = std::stoi(value);
       else
-        hw_json["HW"]["cpu"][metricToName.at(key)] = value;
+        hw_json["HW"]["cpu"][metric.second] = value;
       break;
     }
   }

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -110,13 +110,11 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
     value = std::regex_replace(value, std::regex("^\\s+|\\s+$"), "");
 
     // Fill the JSON with the information
-    for (const auto& metric : metricToName) {
-      if (key != metric.first) continue;
+    if (metricToName.count(key) == 1) {
       if (isNumber(value))
-        hw_json["HW"]["cpu"][metric.second] = std::stoi(value);
+        hw_json["HW"]["cpu"][key] = std::stoi(value);
       else
-        hw_json["HW"]["cpu"][metric.second] = value;
-      break;
+        hw_json["HW"]["cpu"][key] = value;
     }
   }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -76,7 +76,7 @@ void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
   }
 
   // Map lscpu names to the desired ones in the JSON
-  const std::map<std::string, std::string> metricToName{
+  const std::unordered_map<std::string, std::string> metricToName{
       {"Model name", "ModelName"},
       {"CPU(s)", "CPUs"},
       {"Socket(s)", "Sockets"},


### PR DESCRIPTION
As we discussed in #135 using `lscpu` instead of manually reading/parsing `/proc/cpuinfo` is more robust against various architectures (especially non-x86). This is especially easy now given that we have `prmon::cmd_pipe_output` to invoke any command. On my laptop, the output looks like this now:

```
{
  ...  
  "HW": {
    "cpu": {
      "Core(s) per socket": 1,
      "Model name": "Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz",
      "Socket(s)": 4,
      "Thread(s) per core": 1
    },  
    "mem": {
      "MemTotal": 2038904
    }   
  },  
  ...
}
```

Closes #136.