### PR TITLE
Enable hardware information collection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `prmon` binary is invoked with the following arguments:
 
 ```sh
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
-      [--interval 30] [--store-hw-info] [--netdev DEV] \
+      [--interval 30] [--suppress-hw-info] [--netdev DEV] \
       [-- prog arg arg ...]
 ```
 
@@ -90,7 +90,7 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
 * `--filename` output file for timestamped monitored values
 * `--json-summmary` output file for summary data written in JSON format
 * `--interval` time, in seconds, between monitoring snapshots
-* `--store-hw-info` flag that turns-on hardware information collection
+* `--suppress-hw-info` flag that turns-off hardware information collection
 * `--netdev` restricts network statistics to one (or more) network devices
 * `--` after this argument the following arguments are treated as a program to invoke
   and remaining arguments are passed to it; `prmon` will then monitor this process

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[]) {
   const char* default_filename = "prmon.txt";
   const char* default_json_summary = "prmon.json";
   const unsigned int default_interval = 30;
-  const bool default_store_hw_info = false;
+  const bool default_store_hw_info = true;
 
   pid_t pid = -1;
   bool got_pid = false;
@@ -192,7 +192,7 @@ int main(int argc, char* argv[]) {
       {"filename", required_argument, NULL, 'f'},
       {"json-summary", required_argument, NULL, 'j'},
       {"interval", required_argument, NULL, 'i'},
-      {"store-hw-info", no_argument, NULL, 's'},
+      {"suppress-hw-info", no_argument, NULL, 's'},
       {"netdev", required_argument, NULL, 'n'},
       {"help", no_argument, NULL, 'h'},
       {0, 0, 0, 0}};
@@ -215,7 +215,7 @@ int main(int argc, char* argv[]) {
         interval = std::stoi(optarg);
         break;
       case 's':
-        store_hw_info = true;
+        store_hw_info = false;
         break;
       case 'n':
         netdevs.push_back(optarg);
@@ -245,8 +245,8 @@ int main(int argc, char* argv[]) {
         << default_json_summary << ")\n"
         << "[--interval, -i TIME]     Seconds between samples (default "
         << default_interval << ")\n"
-        << "[--store-hw-info, -s]     Store hardware information (default "
-        << (default_store_hw_info ? "true" : "false") << ")\n"
+        << "[--suppress-hw-info, -s]  Disable hardware information (default "
+        << (default_store_hw_info ? "false" : "true") << ")\n"
         << "[--netdev, -n dev]        Network device to monitor (can be given\n"
         << "                          multiple times; default ALL devices)\n"
         << "[--] prog [arg] ...       Instead of monitoring a PID prmon will\n"


### PR DESCRIPTION
With this PR we enable the hardware information collection by default. One can use `-s` or `--suppress-hw-info` to disable it. Let me know how this looks @graeme-a-stewart, many thanks 😊 

Closes #141 