### PR TITLE
Relax test checks on numerical values

### DIFF
--- a/package/tests/testCPU.py
+++ b/package/tests/testCPU.py
@@ -46,9 +46,9 @@ def setupConfigurableTest(threads=1, procs=1, child_fraction=1.0, time=10.0, sla
                 # CPU time tests
                 totCPU = prmonJSON["Max"]["utime"] + prmonJSON["Max"]["stime"]
                 expectCPU = (1.0 + (procs-1)*child_fraction) * time * threads
-                self.assertLess(totCPU, expectCPU, "Too high value for CPU time "
+                self.assertLessEqual(totCPU, expectCPU, "Too high value for CPU time "
                                 "(expected maximum of {0}, got {1})".format(expectCPU, totCPU))
-                self.assertGreater(totCPU, expectCPU*slack, "Too low value for CPU time "
+                self.assertGreaterEqual(totCPU, expectCPU*slack, "Too low value for CPU time "
                                    "(expected minimum of {0}, got {1}".format(expectCPU*slack, totCPU))
                 # Wall time tests
                 totWALL = prmonJSON["Max"]["wtime"]
@@ -66,7 +66,7 @@ if __name__ == '__main__':
     parser.add_argument('--procs', type=int, default=1)
     parser.add_argument('--child-fraction', type=float, default=1.0)
     parser.add_argument('--time', type=float, default=10)
-    parser.add_argument('--slack', type=float, default=0.75)
+    parser.add_argument('--slack', type=float, default=0.7)
     parser.add_argument('--interval', type=int, default=1)
     parser.add_argument('--invoke', dest='invoke', action='store_true', default=False)
 

--- a/package/tests/testIO.py
+++ b/package/tests/testIO.py
@@ -34,9 +34,9 @@ def setupConfigurableTest(io=10, threads=1, procs=1, usleep=10, pause=1, slack=0
 
                 # IO tests
                 expectedBytes = io*threads*procs*slack * 1.0e6
-                self.assertGreater(prmonJSON["Max"]["wchar"], expectedBytes, "Too low value for IO bytes written "
+                self.assertGreaterEqual(prmonJSON["Max"]["wchar"], expectedBytes, "Too low value for IO bytes written "
                                    "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["wchar"]))
-                self.assertGreater(prmonJSON["Max"]["rchar"], expectedBytes, "Too low value for IO bytes read "
+                self.assertGreaterEqual(prmonJSON["Max"]["rchar"], expectedBytes, "Too low value for IO bytes read "
                                    "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["rchar"]))
     
     return configurableProcessMonitor
@@ -49,7 +49,7 @@ if __name__ == '__main__':
     parser.add_argument('--io', type=int, default=10)
     parser.add_argument('--usleep', type=int, default=10)
     parser.add_argument('--pause', type=float, default=1)
-    parser.add_argument('--slack', type=float, default=0.95)
+    parser.add_argument('--slack', type=float, default=0.9)
     parser.add_argument('--interval', type=int, default=1)
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments

--- a/package/tests/testMEM.py
+++ b/package/tests/testMEM.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     parser.add_argument('--malloc', type=int, default=100)
     parser.add_argument('--writef', type=float, default=0.5)
     parser.add_argument('--sleep', type=int, default=10)
-    parser.add_argument('--slack', type=float, default=0.9)
+    parser.add_argument('--slack', type=float, default=0.85)
     parser.add_argument('--interval', type=int, default=1)  
 
     args = parser.parse_args()

--- a/package/tests/testNET.py
+++ b/package/tests/testNET.py
@@ -48,9 +48,9 @@ def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slac
 
                 # Network tests
                 expectedBytes = 1025000 * requests * slack
-                self.assertGreater(prmonJSON["Max"]["rx_bytes"], expectedBytes, "Too low value for rx bytes "
+                self.assertGreaterEqual(prmonJSON["Max"]["rx_bytes"], expectedBytes, "Too low value for rx bytes "
                                    "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["rx_bytes"]))
-                self.assertGreater(prmonJSON["Max"]["tx_bytes"], expectedBytes, "Too low value for tx bytes "
+                self.assertGreaterEqual(prmonJSON["Max"]["tx_bytes"], expectedBytes, "Too low value for tx bytes "
                                    "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tx_bytes"]))
     
     return configurableProcessMonitor
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     parser.add_argument('--requests', type=int, default=10)
     parser.add_argument('--sleep', type=float)
     parser.add_argument('--pause', type=float)
-    parser.add_argument('--slack', type=float, default=0.95)
+    parser.add_argument('--slack', type=float, default=0.8)
     parser.add_argument('--interval', type=int, default=1)
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments

--- a/package/tests/testNET2.py
+++ b/package/tests/testNET2.py
@@ -49,9 +49,9 @@ def setupConfigurableTest(blocks=None, requests=10, sleep=None, pause=None, slac
 
                 # Network tests
                 expectedBytes = 1025000 * requests * slack
-                self.assertGreater(prmonJSON["Max"]["rx_bytes"], expectedBytes, "Too low value for rx bytes "
+                self.assertGreaterEqual(prmonJSON["Max"]["rx_bytes"], expectedBytes, "Too low value for rx bytes "
                                    "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["rx_bytes"]))
-                self.assertGreater(prmonJSON["Max"]["tx_bytes"], expectedBytes, "Too low value for tx bytes "
+                self.assertGreaterEqual(prmonJSON["Max"]["tx_bytes"], expectedBytes, "Too low value for tx bytes "
                                    "(expected minimum of {0}, got {1})".format(expectedBytes, prmonJSON["Max"]["tx_bytes"]))
     
     return configurableProcessMonitor
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     parser.add_argument('--requests', type=int, default=10)
     parser.add_argument('--sleep', type=float)
     parser.add_argument('--pause', type=float)
-    parser.add_argument('--slack', type=float, default=0.95)
+    parser.add_argument('--slack', type=float, default=0.90)
     parser.add_argument('--interval', type=int, default=1)
     args = parser.parse_args()
     # Stop unittest from being confused by the arguments


### PR DESCRIPTION
As the tests run are quite short jitter makes them
fail occasionally (especially in Docker containers
on OS X for some reason). This change relaxes a bit
the numerics to cut these false positives.

Closes #138 