### PR TITLE
Limit decimal places in JSON output of averages

### DIFF
--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -131,16 +131,16 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
           auto wallclock_time = wallclock_monitor_p->get_wallclock_clock_t();
           for (const auto& stat :
                monitor.second->get_json_average_stats(wallclock_time)) {
-            // We will limit the accuracy here to per-mil as it doesn't
+            // We will limit the decimal place accuracy here as it doesn't
             // make any sense to provide tens of decimal places of
             // precision (this is a limitation of the nlohmann::json
             // library, which is always striving for minimal precision
             // loss when converting float types to decimal strings)
             double integer_piece;
-            // Volatile to prevent optimisation if rounding
+            // Volatile to prevent optimisation if performing rounding
             volatile double fractional_piece;
             fractional_piece = std::modf(stat.second, &integer_piece);
-            // The rounding method casting to int, then back to double is
+            // The rounding method of casting to int, then back to double is
             // expensive, so try to avoid it
             if (integer_piece > prmon::avg_precision ||
                 fractional_piece == 0.0) {

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -131,7 +131,27 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
           auto wallclock_time = wallclock_monitor_p->get_wallclock_clock_t();
           for (const auto& stat :
                monitor.second->get_json_average_stats(wallclock_time)) {
-            json_summary["Avg"][(stat.first).c_str()] = stat.second;
+            // We will limit the accuracy here to per-mil as it doesn't
+            // make any sense to provide tens of decimal places of
+            // precision (this is a limitation of the nlohmann::json
+            // library, which is always striving for minimal precision
+            // loss when converting float types to decimal strings)
+            double integer_piece;
+            // Volatile to prevent optimisation if rounding
+            volatile double fractional_piece;
+            fractional_piece = std::modf(stat.second, &integer_piece);
+            // The rounding method casting to int, then back to double is
+            // expensive, so try to avoid it
+            if (integer_piece > prmon::avg_precision ||
+                fractional_piece == 0.0) {
+              json_summary["Avg"][(stat.first).c_str()] = integer_piece;
+            } else {
+              fractional_piece =
+                  static_cast<int>(fractional_piece * prmon::avg_precision) /
+                  static_cast<double>(prmon::avg_precision);
+              json_summary["Avg"][(stat.first).c_str()] =
+                  integer_piece + fractional_piece;
+            }
           }
         }
 

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -27,6 +27,10 @@ void SignalCallbackHandler(int);
 // Child process reaper
 void reap_children();
 
+// Precision specifier for average output, to limit
+// to 1 per 1000 (permil)
+const long avg_precision = 1000;
+
 }  // namespace prmon
 
 #endif  // PRMON_UTIL_H

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -27,8 +27,8 @@ void SignalCallbackHandler(int);
 // Child process reaper
 void reap_children();
 
-// Precision specifier for average output, to truncate to an integer 
-// for anything >avg_precision and round the fraction to 
+// Precision specifier for average output, to truncate to an integer
+// for anything >avg_precision and round the fraction to
 // essentially 1/avg_precision (thus 1000 = 3 decimal places) for
 // anything smaller
 const long avg_precision = 1000;

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -27,8 +27,10 @@ void SignalCallbackHandler(int);
 // Child process reaper
 void reap_children();
 
-// Precision specifier for average output, to limit
-// to 1 per 1000 (permil)
+// Precision specifier for average output, to truncate to an integer 
+// for anything >avg_precision and round the fraction to 
+// essentially 1/avg_precision (thus 1000 = 3 decimal places) for
+// anything smaller
 const long avg_precision = 1000;
 
 }  // namespace prmon


### PR DESCRIPTION
As nlohmann::json always attempts to maintain full precision
when converting from a C++ float/double to a JSON number
it prints way too many decimal places in many cases.

Use std::modf to split the double precision value into integer
and fractional pieces and then truncate the DPs if needed.

Note that it's quite tricky to do this, so the fractional piece is
stored as a volatile to prevent the 'int(value*N)/double(N)' from
being optimised away. Note also that this is quite an expensive
operation, but in the context of prmon we can afford this at the
typical monitoring cadence.

Closes #158 