### PR TITLE
Convert nvidiamon enc/dec metrics from int to string

### DIFF
--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -62,9 +62,9 @@ void nvidiamon::update_stats(const std::vector<pid_t>& pids) {
   }
 
   // Loop over output
-  unsigned int gpu_idx{}, sm{}, mem{}, enc{}, dec{}, fb_mem{};
+  unsigned int gpu_idx{}, sm{}, mem{}, fb_mem{};
   pid_t pid{};
-  std::string cg_type{}, cmd_name{};
+  std::string enc{}, dec{}, cg_type{}, cmd_name{};
   std::unordered_map<unsigned int, bool>
       activegpus{};  // Avoid double counting active GPUs
   for (const auto& s : cmd_result.second) {


### PR DESCRIPTION
This probably depends on a combination of the hardware/software/firmware but it looks like an output from `nvidia-smi pmon [...]` of the form:

```
# gpu        pid  type    sm   mem   enc   dec   command
# Idx          #   C/G     %     %     %     %   name
    0      14294     C    34     0     -     -   177   burner
```

is just as valid as:

```
# gpu        pid  type    sm   mem   enc   dec   command
# Idx          #   C/G     %     %     %     %   name
    0      14294     C    34     0     0     0   177   burner
```

Presumably not all metrics, especially `enc` and `dec`, are always available. 

The main problem this creates is that the current implementation of the output parsing doesn't handle the first case well, resulting in all zero values for the `gpu` related metrics. In any case, we currently don't really track `enc` and `dec` explicitly. Therefore, I converted their types from `unsigned int` to `std::string` so that the parsing succeeds.

This should fix the problem that we've encountered in ADC (gpu related metrics being all zeros). 

-s