### PR TITLE
Respect CLANG_FORMAT setting

### DIFF
--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -17,7 +17,7 @@ file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
 # versions to baulk
 add_custom_target(
         clang-format
-        COMMAND clang-format
+        COMMAND ${CLANG_FORMAT}
         --style=Google
         -i
         ${ALL_SOURCE_FILES}


### PR DESCRIPTION
We allowed `CLANG_FORMAT` to be set through CMake, but the forgot to respect it - fixed.

Closes #170 