### PR TITLE
Implement fix for missing i/o values

### DIFF
--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -26,8 +26,12 @@ class iomon final : public Imonitor {
   // Which network io paramters to measure and output key names
   std::vector<std::string> io_params;
 
-  // Container for stats
+  // Container for stats, one container that holds
+  // the current stats and a backup container for
+  // maximum values, in case the process tree loses some
+  // i/o values (see Github #173)
   std::map<std::string, unsigned long long> io_stats;
+  std::map<std::string, unsigned long long> io_max_stats;
 
  public:
   iomon();


### PR DESCRIPTION
Under some circumstances that are not very well
understood the process tree chain loses i/o values
(which would normally always be "inherited" by
parent processes as children exit).

To compensate for this the iomon module will now
record maximum i/o stats, and if the polled values
are below these it will replace the stats with the
previous maximums. A warning is also printed.

To test this logic there is a defined variable in
iomon.cpp that switches on code that artificially
provokes the problem, exercising the recovery
logic.

Closes #173