### PR TITLE
Add prmon version to the JSON output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/prmonVersion.h
                ${CMAKE_CURRENT_BINARY_DIR}/prmonVersion.h )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/prmonVersion.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/prmon )
+include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
 
 #--- add CMake infrastructure --------------------------------------------------
 include(cmake/prmonCreateConfig.cmake)

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -22,11 +22,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include "prmonVersion.h"
 #include "prmonutils.h"
 #include "registry.h"
 #include "wallmon.h"
-
-#include "prmonVersion.h"
 
 bool prmon::sigusr1 = false;
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -26,6 +26,8 @@
 #include "registry.h"
 #include "wallmon.h"
 
+#include "prmonVersion.h"
+
 bool prmon::sigusr1 = false;
 
 int ProcessMonitor(const pid_t mpid, const std::string filename,
@@ -79,6 +81,9 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
   tmp_json_file << json_summary_file << "_tmp";
   std::stringstream json_snapshot_file;
   json_snapshot_file << json_summary_file << "_snapshot";
+
+  // Add prmon version file to the JSON
+  json_summary["Version"] = prmon_VERSION;
 
   // Collect some hardware information first (if requested)
   if (store_hw_info) {

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -82,7 +82,7 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
   json_snapshot_file << json_summary_file << "_snapshot";
 
   // Add prmon version file to the JSON
-  json_summary["Version"] = prmon_VERSION;
+  json_summary["prmon"]["Version"] = prmon_VERSION;
 
   // Collect some hardware information first (if requested)
   if (store_hw_info) {

--- a/prmonVersion.h
+++ b/prmonVersion.h
@@ -1,4 +1,4 @@
 #ifndef prmonVersion_h
 #define prmonVersion_h
-#define prmon_VERSION @prmon_VERSION @
+#define prmon_VERSION "@prmon_VERSION@"
 #endif


### PR DESCRIPTION
Hi @graeme-a-stewart,

This is one way to proceed w/ adding the version number to the JSON. Actually, maybe we can tweak the `CMakeLists.txt` a bit to put the correct version of `prmonVersion.h` in a dedicated folder and add that to the include directories to make things a bit tidier but this should functionally work:

```
{
  "Avg": {
    "nprocs": 1.0,
    "nthreads": 1.0,
    "pss": 586.333,
    "rchar": 851.533,
    "read_bytes": 8376.0,
    "rss": 1376.0,
    "rx_bytes": 0.0,
    "rx_packets": 0.0,
    "swap": 0.0,
    "tx_bytes": 0.0,
    "tx_packets": 0.0,
    "vmem": 2516.0,
    "wchar": 0.0,
    "write_bytes": 0.0 
  },  
  "HW": {
    "cpu": {
      "CPUs": 4,
      "CoresPerSocket": 1,
      "ModelName": "Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz",
      "Sockets": 4,
      "ThreadsPerCore": 1
    },  
    "mem": {
      "MemTotal": 2038904
    }   
  },  
  "Max": {
    "nprocs": 1,
    "nthreads": 1,
    "pss": 589,
    "rchar": 4164,
    "read_bytes": 40960,
    "rss": 1376,
    "rx_bytes": 0,
    "rx_packets": 0,
    "stime": 0,
    "swap": 0,
    "tx_bytes": 0,
    "tx_packets": 0,
    "utime": 0,
    "vmem": 2516,
    "wchar": 0,
    "write_bytes": 0,
    "wtime": 4
  },  
  "Version": "2.1.1"
}
```

Please let me know what you think.

Best,
Serhan

Closes #175 