### PR TITLE
Working around a weird quirk of getopt

### DIFF
--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -239,7 +239,7 @@ int main(int argc, char* argv[]) {
       {0, 0, 0, 0}};
 
   int c;
-  while ((c = getopt_long(argc, argv, "p:f:j:i:sun:h", long_options, NULL)) !=
+  while ((c = getopt_long(argc, argv, "-p:f:j:i:sun:h", long_options, NULL)) !=
          -1) {
     switch (char(c)) {
       case 'p':


### PR DESCRIPTION
While testing out #178, I noticed a "feature" of `getopt` that confused me for a while. When the user provides a wrong set of arguments, e.g.:

```
prmon -i 1 foo -- sleep 5
```

The forked process executes `foo` instead of `sleep`. This is because `getopt` seems to re-order `argv` and puts all non-option arguments at the end, i.e.:

```
argv : prmon -i 1 foo -- sleep 5
getopt_long
argv : prmon -i 1 -- foo sleep 5
```

As a result, we not only silently omit the wrong input but also end up calling the wrong command later on. 

With an additional `-` at the beginning of the `optstring` it's possible to catch such issues and piggy-back on the default switch to print a message that suggests using the help. 
