### PR TITLE
Implement monitor disable via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ incomplete arguments. If `prmon` starts a program itself (using `--`) then
 When invoked with `-h` or `--help` usage information is printed, as well as a
 list of all available monitoring components.
 
+### Environment Variables
+
+The `PRMON_DISABLE_MONITOR` environment variable can be used to specifiy a comma
+separated list of monitor names that will be disabled. This is useful when
+`prmon` is being invoked by some other part of a job or workflow, so the user
+does not have direct access to the command line options used. e.g.
+
+```sh
+export PRMON_DISABLE_MONITOR=nvidiamon
+other_code_that_invokes_prmon
+...
+```
+
+Disables the `nvidiamon` monitor.
 ## Outputs
 
 In the `filename` output file, plain text with statistics written every

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -289,6 +289,9 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  // Get additional configuration from the environment
+  prmon::disable_monitors_from_env(disabled_monitors);
+
   if (do_help) {
     std::cout
         << "prmon is a process monitor program that records runtime data\n"

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -24,6 +24,11 @@ std::vector<pid_t> offspring_pids(const pid_t mother_pid);
 // Switch on/off states for individual monitors
 bool valid_monitor_disable(const std::string disable_name);
 
+// Disable monitors from an environment variable
+void disable_monitors_from_env(std::vector<std::string> &disabled_monitors);
+void snip_string_and_test(char *env_string, unsigned start, unsigned pos,
+                          std::vector<std::string> &disabled_monitors);
+
 // Signal handlers
 extern bool sigusr1;
 void SignalCallbackHandler(int);


### PR DESCRIPTION
Allow monitors to be disabled via the `PRMON_DISABLE_MONITOR` environment variable.

Closes #182 