### PR TITLE
Update development branch name to "main"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@
 name: CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master and stable branches
+# events but only for the main and stable branches
 on:
   push:
-    branches: [ master, stable ]
+    branches: [ main, stable ]
   pull_request:
-    branches: [ master, stable ]
+    branches: [ main, stable ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,10 +2,10 @@
 name: Clang-Format
 
 # Controls when the action will run. Triggers the workflow on push
-# except for the master and stable branches
+# except for the main and stable branches
 on:
   push:
-    branches-ignore: [ master, stable ]
+    branches-ignore: [ main, stable ]
 
 # Defines the main job where we checkout our code, run clang-format
 # and commit changes

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,12 +2,12 @@
 name: flake8
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master and stable branches
+# events but only for the main and stable branches
 on:
   push:
-    branches: [ master, stable ]
+    branches: [ main, stable ]
   pull_request:
-    branches: [ master, stable ]
+    branches: [ main, stable ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status][build-img]][build-link]  [![License][license-img]][license-url] [![Codefactor][codefactor-img]][codefactor-url]
 
-[build-img]: https://github.com/HSF/prmon/workflows/CI/badge.svg?branch=master
-[build-link]: https://github.com/HSF/prmon/actions?query=workflow%3ACI+branch%3Amaster
+[build-img]: https://github.com/HSF/prmon/workflows/CI/badge.svg?branch=main
+[build-link]: https://github.com/HSF/prmon/actions?query=workflow%3ACI+branch%3Amain
 [license-img]: https://img.shields.io/github/license/hsf/prmon.svg
-[license-url]: https://github.com/hsf/prmon/blob/master/LICENSE
+[license-url]: https://github.com/hsf/prmon/blob/main/LICENSE
 [codefactor-img]: https://www.codefactor.io/repository/github/HSF/prmon/badge
 [codefactor-url]: https://www.codefactor.io/repository/github/HSF/prmon
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -76,9 +76,9 @@ specific files (like this one) and all improvements are welcome.
 ## Authorship and Copyright
 
 As members of the High-Energy Physics community, our host laboratory,
-[CERN](https://home.cern/), holds copyright on this project. 
+[CERN](https://home.cern/), holds copyright on this project.
 
-All contributions need to agree to pass copyright to CERN. 
+All contributions need to agree to pass copyright to CERN.
 
 Every significant author of prmon will be acknowledged in our
 [AUTHORS](../AUTHORS.md) file.

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -2,10 +2,10 @@
 
 ## Git and GitHub
 
-1. On the master branch make the last feature commits and ensure that all
+1. On the `main` branch make the last feature commits and ensure that all
    tests pass.
 2. Update the release number in `CMakeLists.txt` and commit.
-3. Update the `stable` branch to this commit in `master`.
+3. Update the `stable` branch to this commit in `main`.
 4. Make a tag, following a semantic versioning scheme `vA.B.C`.
   - Use an *annotated* tag, add brief release notes in the annotation.
 5. Push changes to GitHub.


### PR DESCRIPTION
Should have found and fixed all references to the old name for the
development branch as master.

This is the tidy-up post #187.