### PR TITLE
Fix for #191

### DIFF
--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -65,7 +65,7 @@ class Registry {
 
   static std::vector<std::string> list_registered() {
     std::vector<std::string> list{};
-    for (const auto k : ctors()) {
+    for (const auto& k : ctors()) {
       list.push_back(k.first);
     }
     return list;


### PR DESCRIPTION
This one is fairly simple. What we currently have seems to trigger an `-Werror=range-loop-construct` on `gcc11` [1]. Now we simply use a reference to avoid copying.

[1] I took `gcc11` from `source /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-centos7-gcc11-dbg/setup.sh` but we can actually setup a dedicate CI for this.