### PR TITLE
Added command line switches to control logging level of monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ prmon currently runs on Linux machines as it requires access to the
 
 ## Build and Deployment
 
+### Cloning the project
+
+As prmon has dependencies on submodules, clone the project as
+    
+    git clone --recurse-submodules https://github.com/HSF/prmon.git
+    
 ### Building the project
 
 Building prmon requires a C++ compiler that fully supports C++11,
@@ -83,7 +89,7 @@ The `prmon` binary is invoked with the following arguments:
 ```sh
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
       [--interval 30] [--suppress-hw-info] [--units] [--netdev DEV] \
-      [--disable MON1] \
+      [--disable MON1] [--level LEV] [--level MON:LEV]\
       [-- prog arg arg ...]
 ```
 
@@ -97,6 +103,10 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
 * `--disable` is used to disable specific monitors (and can be specified multiple times); 
     the default is that `prmon` monitors everything that it can
   * Note that the `wallmon` monitor is the only monitor that cannot be disabled
+* `--level` is used to set the logging level for monitors
+  * `--level LEV` sets the level for all monitors to LEV
+  * `--level MON:LEV` sets the level for monitor MON to LEV
+  * The valid levels are `trace`, `debug`, `info`, `warn`, `error`, `critical`
 * `--` after this argument the following arguments are treated as a program to invoke
   and remaining arguments are passed to it; `prmon` will then monitor this process
   instead of being given a PID via `--pid`

--- a/package/src/MessageBase.h
+++ b/package/src/MessageBase.h
@@ -1,6 +1,8 @@
 #ifndef PRMON_MESSAGEBASE_H
 #define PRMON_MESSAGEBASE_H 1
 
+#include <map>
+
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
@@ -12,13 +14,23 @@ static const std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
 static const std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
     std::make_shared<spdlog::sinks::basic_file_sink_st>("prmon.log", true)};
 
+// Map from monitor to logging level
+
+extern bool invalid_level_option;
+extern std::map<std::string, spdlog::level::level_enum> monitor_level;
+
+// Processing command line switches
+
+extern spdlog::level::level_enum global_logging_level;
+void processLevel(std::string s);
+
 class MessageBase {
   std::shared_ptr<spdlog::logger> logger;
 
  protected:
   spdlog::level::level_enum log_level;
   void log_init(const std::string& classname,
-                const spdlog::level::level_enum& level = spdlog::level::warn);
+                const spdlog::level::level_enum& level = global_logging_level);
 
  public:
   void set_log_level(const spdlog::level::level_enum& level);


### PR DESCRIPTION
Command line switches `--level LEV` and `--level MON:LEV` have been added. These can be used to set the minimum global logging level as well as minimum logging level for individual monitors.

The README has been updated to include cloning instructions (`--recurse-submodules`) as prmon now includes spdlog submodule. The new command line options have also been updated in the README.

Closes #189, closes #106.