### PR TITLE
Fix: cpumon doesn't reset values each iteration

### DIFF
--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -28,7 +28,7 @@ cpumon::cpumon() : cpu_params{}, cpu_stats{} {
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {
-  for (auto stat : cpu_stats) stat.second = 0;
+  for (auto& stat : cpu_stats) stat.second = 0;
 
   std::vector<std::string> stat_entries{};
   stat_entries.reserve(prmon::stat_cpu_read_limit + 1);


### PR DESCRIPTION
The iterating variable here: https://github.com/HSF/prmon/blob/9e762bc589de6229601b310e4be1adc4e3703d5b/package/src/cpumon.cpp#L31 isn't a reference. Hence, the values remain unchanged and are not reset every iteration.