### PR TITLE
Added new montored value class

### DIFF
--- a/doc/ADDING_MONITORS.md
+++ b/doc/ADDING_MONITORS.md
@@ -10,32 +10,64 @@ the current examples and these are an excellent guide.
 
 ## `parameter.h`
 
-Every monitor describes its column headers (*what* it will monitor) and the
-units for this parameter as a vector of `parameter` classes. This is a very
-simple class, initialised with three strings:
+All monitors need to include this header, which defines utility classes and
+standard types used.
+
+### `parameter` class
+
+This class defines a few properties that are needed for any value that is going
+to be measured by prmon. It consists of three strings:
 - name of parameter
 - units for maximum/continuous value
 - units for average value
 If the later is an empty string it means that there is no meaningful value
-for the average and so nothing is output.
+for the average and so nothing will be output for an average of this stat.
 
-## Data Structures
+Monitors usually define a `const prmon::parameter_list`, which is a vector
+describing all of the parameters that they will measure.
+
+### `monitored_value` class
+
+This class represents a monitored value as measured by a concrete monitor. This
+is initialised from a `parameter` class, plus a boolean flag that signals if the
+monitored quanitity is *monotonic*, i.e., can only increase over time. A third,
+optional, parameter gives an *offset* value that will be subtracted from the
+"input" values. This is useful when a statistic does not start from zero at the
+beginning of the job, e.g., network counter statistics.
+
+The class provides accessors for current, maximum and average values of a
+statistic. There is a setter, `set_value` that should be used to update the
+value of the statistic on each monitoring cycle. There is also a setter for the
+offset, `set_offset` that should only be called before any values have been
+monitored.
+
+`set_value()` will protect a monotonic value from being lowered and prevent any
+attempt to set a value less than any offset.
+
+Monitors generally hold a `prmon::monitored_list`, which is a map from the
+string name of the monitored value to its `monitored_value` instance. In the
+constuctor of the monitor the `monitored_list` is initialised from the
+corresponding `const parameter_list`.
+
+### Data Structures and Types
 
 Every monitor accumulates statistics into maps, with keys corresponding to the
-column header names in `util.h`. Accumulated statistics are `unsigned long long`
-values and average statistics are `double` values.
+parameter names (from `parameter` classes). To ensure consistency and readabity
+these maps are defined as `prmon::monitored_value_map` for snapshot and
+accumulated statistics and `prmon::monitored_average_map` for average statistics
+(the snapshots values are `mon_value`, which is itself defined as
+`unsigned long long`; the averages are `mon_average`, which are `double`).
 
-Most monitors keep statistics counters, for accumulation over time, as well as
-maximum values and average values. These are updated each update cycle.
+Monitors update their parameters in the `monitored_list` and use the getters to
+construct and return the appropriate data structure to the main `prmon` loop.
 
 ## Initialisation
 
 Use an RAII pattern, so that on initialisation the monitor is valid and ready
 to be used.
 
-For most monitors a vector of monitored quantities is constructed from the
-parameter class, as the units are only needed once. Counters are mostly
-set to zero as well.
+For most monitors the `monitored_list` is initalised from the corresponding
+`const parameter_list`.
 
 ## Registry
 
@@ -55,7 +87,8 @@ does.
 Each monitoring cycle active monitors are called using their `update_stats()`
 method. A const vector of process identifiers will be passed in, allowing
 monitors to gather statistics only for processes that are part of the monitored
-job.
+job. For each relevant statistic the `set_value()` setter of the
+`monitored_value` class will be called.
 
 ## Reporting Statistics
 
@@ -63,19 +96,17 @@ There are three statistics reports that your monitor should provide:
 
 ### Current Values
 
-Polled from `get_text_stats()`, pass back a map of string keys (column headers)
-and integral values (`unsigned long long`).
+Polled from `get_text_stats()`, pass back a `prmon::monitored_value_map`.
 
 These statistics will be fed into the *text* output file from prmon.
 
 ### Maximum Values
 
-Polled from `get_json_total_stats()`, pass back a map of string keys (column
-headers) and integral values (`unsigned long long`). These statistics are *peak
-values*, which are the same as the *current values* for statistics that simply
-accumulate over time (e.g., user cpu seconds used or bytes read), but are
-*maximums* in the case of statistics that rise and fall (e.g., number of
-threads).
+Polled from `get_json_total_stats()`, pass back a `prmon::monitored_value_map`.
+These statistics are *peak values*, which are the same as the *current values*
+for statistics that simply accumulate over time (e.g., user cpu seconds used or
+bytes read), but are *maximums* in the case of statistics that rise and fall
+(e.g., number of threads).
 
 These statistics will be fed into the `Max` dictionary element of the JSON
 output from prmon.
@@ -83,12 +114,11 @@ output from prmon.
 ### Average Values
 
 Polled from `get_json_average_stats(elapsed_clock_ticks)`, pass back a map of
-string keys (column headers) and floating point values (`double`). These
-statistics are *average values* for the metric. What than means depends on the
-statistic (e.g., the memory consumption over the job lifetime or the number of
-bytes written per second). If an average makes no real sense for what you
-measure then exclude that metric from the values returned (some monitors report
-nothing here).
+`prmon::monitored_average_map`. These statistics are *average values* for the
+metric. What than means depends on the statistic (e.g., the memory consumption
+over the job lifetime or the number of bytes written per second). If an average
+makes no real sense for what you measure then exclude that metric from the
+values returned (some monitors report nothing here).
 
 These statistics will be fed into the `Avg` dictionary element of the JSON
 output from prmon.

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -3,6 +3,8 @@ find_package(nlohmann_json REQUIRED)
 add_executable(prmon src/prmon.cpp
            src/prmonutils.cpp
            src/utils.cpp
+           src/MessageBase.cpp
+           src/parameter.cpp
            src/netmon.cpp
            src/iomon.cpp
            src/cpumon.cpp
@@ -10,7 +12,6 @@ add_executable(prmon src/prmon.cpp
            src/wallmon.cpp
            src/memmon.cpp
            src/nvidiamon.cpp
-           src/MessageBase.cpp
            )
 if (BUILD_BENCHMARK_LOG)
   add_executable(benchmark-log src/benchmark.cpp)

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -19,19 +19,16 @@
 
 #include "parameter.h"
 
-using monitored_value_map = std::map<std::string, mon_value>;
-using monitored_average_map = std::map<std::string, double>;
-
 class Imonitor {
  public:
   virtual ~Imonitor(){};
 
   virtual void update_stats(const std::vector<pid_t>& pids) = 0;
 
-  virtual monitored_value_map const get_text_stats() = 0;
-  virtual monitored_value_map const get_json_total_stats() = 0;
-  virtual monitored_average_map const get_json_average_stats(
-      mon_value elapsed_clock_ticks) = 0;
+  virtual prmon::monitored_value_map const get_text_stats() = 0;
+  virtual prmon::monitored_value_map const get_json_total_stats() = 0;
+  virtual prmon::monitored_average_map const get_json_average_stats(
+      prmon::mon_value elapsed_clock_ticks) = 0;
 
   virtual void const get_hardware_info(nlohmann::json& hw_json) = 0;
   virtual void const get_unit_info(nlohmann::json& unit_json) = 0;

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -17,17 +17,21 @@
 #include <string>
 #include <vector>
 
+#include "parameter.h"
+
+using monitored_value_map = std::map<std::string, mon_value>;
+using monitored_average_map = std::map<std::string, double>;
+
 class Imonitor {
  public:
   virtual ~Imonitor(){};
 
   virtual void update_stats(const std::vector<pid_t>& pids) = 0;
 
-  virtual std::map<std::string, unsigned long long> const get_text_stats() = 0;
-  virtual std::map<std::string, unsigned long long> const
-  get_json_total_stats() = 0;
-  virtual std::map<std::string, double> const get_json_average_stats(
-      unsigned long long elapsed_clock_ticks) = 0;
+  virtual monitored_value_map const get_text_stats() = 0;
+  virtual monitored_value_map const get_json_total_stats() = 0;
+  virtual monitored_average_map const get_json_average_stats(
+      mon_value elapsed_clock_ticks) = 0;
 
   virtual void const get_hardware_info(nlohmann::json& hw_json) = 0;
   virtual void const get_unit_info(nlohmann::json& unit_json) = 0;

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 #include "countmon.h"

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -16,27 +16,19 @@
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-countmon::countmon()
-    : count_params{},
-      count_stats{},
-      count_peak_stats{},
-      count_average_stats{},
-      count_total_stats{},
-      iterations{0L} {
+countmon::countmon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
-  count_params.reserve(params.size());
   for (const auto& param : params) {
-    count_params.push_back(param.get_name());
-    count_stats[param.get_name()] = 0;
-    count_peak_stats[param.get_name()] = 0;
-    count_average_stats[param.get_name()] = 0;
-    count_total_stats[param.get_name()] = 0;
+    count_stats.emplace(std::make_pair(param.get_name(), param));
   }
 }
 
 void countmon::update_stats(const std::vector<pid_t>& pids) {
-  for (auto& stat : count_stats) stat.second = 0;
+  prmon::monitored_value_map count_stat_update{};
+  for (const auto& stat : count_stats) {
+    count_stat_update[stat.first] = 0L;
+  }
 
   std::vector<std::string> stat_entries{};
   stat_entries.reserve(prmon::stat_count_read_limit + 1);
@@ -51,38 +43,44 @@ void countmon::update_stats(const std::vector<pid_t>& pids) {
       if (proc_stat) stat_entries.push_back(tmp_str);
     }
     if (stat_entries.size() > prmon::stat_count_read_limit) {
-      count_stats["nprocs"] += 1L;
-      count_stats["nthreads"] += std::stol(stat_entries[prmon::num_threads]);
+      count_stat_update["nprocs"] += 1L;
+      count_stat_update["nthreads"] +=
+          std::stol(stat_entries[prmon::num_threads]);
     }
     stat_entries.clear();
   }
 
   // Update the statistics with the new snapshot values
-  ++iterations;
-  for (const auto& count_param : count_params) {
-    if (count_stats[count_param] > count_peak_stats[count_param])
-      count_peak_stats[count_param] = count_stats[count_param];
-    count_total_stats[count_param] += count_stats[count_param];
-    count_average_stats[count_param] =
-        double(count_total_stats[count_param]) / iterations;
-  }
+  for (auto& value : count_stats)
+    value.second.set_value(count_stat_update[value.first]);
 }
 
-// Return the counters
-std::map<std::string, unsigned long long> const countmon::get_text_stats() {
-  return count_stats;
+// Return the counter map
+prmon::monitored_value_map const countmon::get_text_stats() {
+  prmon::monitored_value_map count_stat_map{};
+  for (const auto& value : count_stats) {
+    count_stat_map[value.first] = value.second.get_value();
+  }
+  return count_stat_map;
 }
 
 // For JSON return the peaks
-std::map<std::string, unsigned long long> const
-countmon::get_json_total_stats() {
-  return count_peak_stats;
+prmon::monitored_value_map const countmon::get_json_total_stats() {
+  prmon::monitored_value_map count_max_stat_map{};
+  for (const auto& value : count_stats) {
+    count_max_stat_map[value.first] = value.second.get_max_value();
+  }
+  return count_max_stat_map;
 }
 
 // An the averages
-std::map<std::string, double> const countmon::get_json_average_stats(
+prmon::monitored_average_map const countmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  return count_average_stats;
+  prmon::monitored_average_map count_avg_stat_map{};
+  for (const auto& value : count_stats) {
+    count_avg_stat_map[value.first] = value.second.get_average_value();
+  }
+  return count_avg_stat_map;
 }
 
 // Collect related hardware information

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -20,7 +20,7 @@ countmon::countmon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    count_stats.emplace(std::make_pair(param.get_name(), param));
+    count_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param)));
   }
 }
 

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -20,7 +20,8 @@ countmon::countmon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    count_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param)));
+    count_stats.emplace(
+        std::make_pair(param.get_name(), prmon::monitored_value(param)));
   }
 }
 

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -20,8 +20,7 @@ countmon::countmon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    count_stats.emplace(
-        std::make_pair(param.get_name(), prmon::monitored_value(param)));
+    count_stats.emplace(param.get_name(), prmon::monitored_value(param));
   }
 }
 

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -23,17 +23,10 @@ class countmon final : public Imonitor, public MessageBase {
   const prmon::parameter_list params = {{"nprocs", "1", "1"},
                                         {"nthreads", "1", "1"}};
 
-  // Which network count paramters to measure and output key names
-  std::vector<std::string> count_params;
-
-  // Container for total stats
-  std::map<std::string, unsigned long long> count_stats;
-  std::map<std::string, unsigned long long> count_peak_stats;
-  std::map<std::string, double> count_average_stats;
-  std::map<std::string, unsigned long long> count_total_stats;
-
-  // Counter for number of iterations
-  unsigned long iterations;
+  // Dynamic monitoring container for value measurements
+  // This will be filled at initialisation, taking the names
+  // from the above params
+  prmon::monitored_list count_stats;
 
  public:
   countmon();
@@ -41,9 +34,9 @@ class countmon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  std::map<std::string, unsigned long long> const get_text_stats();
-  std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(
+  prmon::monitored_value_map const get_text_stats();
+  prmon::monitored_value_map const get_json_total_stats();
+  prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 // Process and thread number monitoring class

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 #include "cpumon.h"

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -17,18 +17,21 @@
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-cpumon::cpumon() : cpu_params{}, cpu_stats{} {
+cpumon::cpumon() : cpu_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
-  cpu_params.reserve(params.size());
   for (const auto& param : params) {
-    cpu_params.push_back(param.get_name());
-    cpu_stats[param.get_name()] = 0;
+    cpu_stats.emplace(std::make_pair(param.get_name(),
+    prmon::monitored_value(param.get_name(), param.get_max_unit(),
+    param.get_avg_unit())));
   }
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {
-  for (auto& stat : cpu_stats) stat.second = 0;
+  monitored_value_map stat_update{};
+  for (const auto &stat : cpu_stats) {
+    stat_update[stat.first] = 0L;
+  }
 
   std::vector<std::string> stat_entries{};
   stat_entries.reserve(prmon::stat_cpu_read_limit + 1);
@@ -42,30 +45,34 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
       if (proc_stat) stat_entries.push_back(tmp_str);
     }
     if (stat_entries.size() > prmon::stat_cpu_read_limit) {
-      cpu_stats["utime"] += std::stol(stat_entries[prmon::utime_pos]) +
+      stat_update["utime"] += std::stol(stat_entries[prmon::utime_pos]) +
                             std::stol(stat_entries[prmon::cutime_pos]);
-      cpu_stats["stime"] += std::stol(stat_entries[prmon::stime_pos]) +
+      stat_update["stime"] += std::stol(stat_entries[prmon::stime_pos]) +
                             std::stol(stat_entries[prmon::cstime_pos]);
     }
     stat_entries.clear();
   }
-  for (auto& stat : cpu_stats) stat.second /= sysconf(_SC_CLK_TCK);
+  for (auto& stat : cpu_stats) stat.second.set_value(stat_update[stat.first] / sysconf(_SC_CLK_TCK));
 }
 
 // Return the summed counters
-std::map<std::string, unsigned long long> const cpumon::get_text_stats() {
-  return cpu_stats;
+monitored_value_map const cpumon::get_text_stats() {
+  monitored_value_map stat_map{};
+  for (const auto &value : cpu_stats) {
+    stat_map[value.first] = value.second.get_value();
+  }
+  return stat_map;
 }
 
 // Same for JSON
-std::map<std::string, unsigned long long> const cpumon::get_json_total_stats() {
-  return cpu_stats;
+monitored_value_map const cpumon::get_json_total_stats() {
+  return cpumon::get_text_stats();
 }
 
 // For CPU time there's nothing to return for an average
-std::map<std::string, double> const cpumon::get_json_average_stats(
+monitored_average_map const cpumon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, double> empty_average_stats{};
+  monitored_average_map empty_average_stats{};
   return empty_average_stats;
 }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -21,7 +21,8 @@ cpumon::cpumon() : cpu_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    cpu_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
+    cpu_stats.emplace(
+        std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
   }
 }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -21,7 +21,7 @@ cpumon::cpumon() : cpu_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    cpu_stats.emplace(std::make_pair(param.get_name(), param));
+    cpu_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
   }
 }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -21,8 +21,7 @@ cpumon::cpumon() : cpu_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    cpu_stats.emplace(
-        std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
+    cpu_stats.emplace(param.get_name(), prmon::monitored_value(param, true));
   }
 }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -26,7 +26,7 @@ cpumon::cpumon() : cpu_stats{} {
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {
-  monitored_value_map stat_update{};
+  prmon::monitored_value_map stat_update{};
   for (const auto& stat : cpu_stats) {
     stat_update[stat.first] = 0L;
   }
@@ -55,8 +55,8 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
 }
 
 // Return the summed counters
-monitored_value_map const cpumon::get_text_stats() {
-  monitored_value_map stat_map{};
+prmon::monitored_value_map const cpumon::get_text_stats() {
+  prmon::monitored_value_map stat_map{};
   for (const auto& value : cpu_stats) {
     stat_map[value.first] = value.second.get_value();
   }
@@ -64,14 +64,14 @@ monitored_value_map const cpumon::get_text_stats() {
 }
 
 // Same for JSON
-monitored_value_map const cpumon::get_json_total_stats() {
+prmon::monitored_value_map const cpumon::get_json_total_stats() {
   return cpumon::get_text_stats();
 }
 
 // For CPU time there's nothing to return for an average
-monitored_average_map const cpumon::get_json_average_stats(
+prmon::monitored_average_map const cpumon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  static const monitored_average_map empty_average_stats{};
+  static const prmon::monitored_average_map empty_average_stats{};
   return empty_average_stats;
 }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -21,15 +21,13 @@ cpumon::cpumon() : cpu_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    cpu_stats.emplace(std::make_pair(param.get_name(),
-    prmon::monitored_value(param.get_name(), param.get_max_unit(),
-    param.get_avg_unit())));
+    cpu_stats.emplace(std::make_pair(param.get_name(), param));
   }
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {
   monitored_value_map stat_update{};
-  for (const auto &stat : cpu_stats) {
+  for (const auto& stat : cpu_stats) {
     stat_update[stat.first] = 0L;
   }
 
@@ -46,19 +44,20 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
     }
     if (stat_entries.size() > prmon::stat_cpu_read_limit) {
       stat_update["utime"] += std::stol(stat_entries[prmon::utime_pos]) +
-                            std::stol(stat_entries[prmon::cutime_pos]);
+                              std::stol(stat_entries[prmon::cutime_pos]);
       stat_update["stime"] += std::stol(stat_entries[prmon::stime_pos]) +
-                            std::stol(stat_entries[prmon::cstime_pos]);
+                              std::stol(stat_entries[prmon::cstime_pos]);
     }
     stat_entries.clear();
   }
-  for (auto& stat : cpu_stats) stat.second.set_value(stat_update[stat.first] / sysconf(_SC_CLK_TCK));
+  for (auto& stat : cpu_stats)
+    stat.second.set_value(stat_update[stat.first] / sysconf(_SC_CLK_TCK));
 }
 
 // Return the summed counters
 monitored_value_map const cpumon::get_text_stats() {
   monitored_value_map stat_map{};
-  for (const auto &value : cpu_stats) {
+  for (const auto& value : cpu_stats) {
     stat_map[value.first] = value.second.get_value();
   }
   return stat_map;
@@ -72,7 +71,7 @@ monitored_value_map const cpumon::get_json_total_stats() {
 // For CPU time there's nothing to return for an average
 monitored_average_map const cpumon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  monitored_average_map empty_average_stats{};
+  static const monitored_average_map empty_average_stats{};
   return empty_average_stats;
 }
 

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -26,9 +26,9 @@ cpumon::cpumon() : cpu_stats{} {
 }
 
 void cpumon::update_stats(const std::vector<pid_t>& pids) {
-  prmon::monitored_value_map stat_update{};
-  for (const auto& stat : cpu_stats) {
-    stat_update[stat.first] = 0L;
+  prmon::monitored_value_map cpu_stat_update{};
+  for (const auto& value : cpu_stats) {
+    cpu_stat_update[value.first] = 0L;
   }
 
   std::vector<std::string> stat_entries{};
@@ -43,24 +43,24 @@ void cpumon::update_stats(const std::vector<pid_t>& pids) {
       if (proc_stat) stat_entries.push_back(tmp_str);
     }
     if (stat_entries.size() > prmon::stat_cpu_read_limit) {
-      stat_update["utime"] += std::stol(stat_entries[prmon::utime_pos]) +
-                              std::stol(stat_entries[prmon::cutime_pos]);
-      stat_update["stime"] += std::stol(stat_entries[prmon::stime_pos]) +
-                              std::stol(stat_entries[prmon::cstime_pos]);
+      cpu_stat_update["utime"] += std::stol(stat_entries[prmon::utime_pos]) +
+                                  std::stol(stat_entries[prmon::cutime_pos]);
+      cpu_stat_update["stime"] += std::stol(stat_entries[prmon::stime_pos]) +
+                                  std::stol(stat_entries[prmon::cstime_pos]);
     }
     stat_entries.clear();
   }
-  for (auto& stat : cpu_stats)
-    stat.second.set_value(stat_update[stat.first] / sysconf(_SC_CLK_TCK));
+  for (auto& value : cpu_stats)
+    value.second.set_value(cpu_stat_update[value.first] / sysconf(_SC_CLK_TCK));
 }
 
 // Return the summed counters
 prmon::monitored_value_map const cpumon::get_text_stats() {
-  prmon::monitored_value_map stat_map{};
+  prmon::monitored_value_map cpu_stat_map{};
   for (const auto& value : cpu_stats) {
-    stat_map[value.first] = value.second.get_value();
+    cpu_stat_map[value.first] = value.second.get_value();
   }
-  return stat_map;
+  return cpu_stat_map;
 }
 
 // Same for JSON

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 // CPU monitoring class

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -16,6 +16,9 @@
 #include "MessageBase.h"
 #include "parameter.h"
 #include "registry.h"
+
+using monitored_list = std::map<std::string, prmon::monitored_value>;
+
 class cpumon final : public Imonitor, public MessageBase {
  private:
   // Setup the parameters to monitor here
@@ -24,10 +27,7 @@ class cpumon final : public Imonitor, public MessageBase {
   // Which network cpu paramters to measure and output key names
   // This will be filled at initialisation, taking the names
   // from the above params
-  std::vector<std::string> cpu_params;
-
-  // Container for total stats
-  std::map<std::string, unsigned long long> cpu_stats;
+  monitored_list cpu_stats;
 
  public:
   cpumon();
@@ -35,9 +35,9 @@ class cpumon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  std::map<std::string, unsigned long long> const get_text_stats();
-  std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(
+  monitored_value_map const get_text_stats();
+  monitored_value_map const get_json_total_stats();
+  monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -17,17 +17,15 @@
 #include "parameter.h"
 #include "registry.h"
 
-using monitored_list = std::map<std::string, prmon::monitored_value>;
-
 class cpumon final : public Imonitor, public MessageBase {
  private:
   // Setup the parameters to monitor here
   const prmon::parameter_list params = {{"utime", "s", ""}, {"stime", "s", ""}};
 
-  // Which network cpu paramters to measure and output key names
+  // Dynamic monitoring container for value measurements
   // This will be filled at initialisation, taking the names
   // from the above params
-  monitored_list cpu_stats;
+  prmon::monitored_list cpu_stats;
 
  public:
   cpumon();
@@ -35,9 +33,9 @@ class cpumon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  monitored_value_map const get_text_stats();
-  monitored_value_map const get_json_total_stats();
-  monitored_average_map const get_json_average_stats(
+  prmon::monitored_value_map const get_text_stats();
+  prmon::monitored_value_map const get_json_total_stats();
+  prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -22,7 +22,8 @@ iomon::iomon() : io_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    io_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
+    io_stats.emplace(
+        std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
   }
 }
 
@@ -88,7 +89,8 @@ prmon::monitored_average_map const iomon::get_json_average_stats(
   prmon::monitored_average_map io_average_stats{};
   for (const auto& io_param : io_stats) {
     io_average_stats[io_param.first] =
-        double(io_param.second.get_value() * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
+        double(io_param.second.get_value() * sysconf(_SC_CLK_TCK)) /
+        elapsed_clock_ticks;
   }
   return io_average_stats;
 }

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -88,7 +88,7 @@ prmon::monitored_average_map const iomon::get_json_average_stats(
   prmon::monitored_average_map io_average_stats{};
   for (const auto& io_param : io_stats) {
     io_average_stats[io_param.first] =
-        double(io_param.second.get_value() * sysconf(_SC_CLK_TCK)) /
+        prmon::avg_value(io_param.second.get_value() * sysconf(_SC_CLK_TCK)) /
         elapsed_clock_ticks;
   }
   return io_average_stats;

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -22,8 +22,7 @@ iomon::iomon() : io_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    io_stats.emplace(
-        std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
+    io_stats.emplace(param.get_name(), prmon::monitored_value(param, true));
   }
 }
 

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -18,22 +18,22 @@
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-iomon::iomon() : io_params{}, io_stats{} {
+iomon::iomon() : io_stats{} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
-  io_params.reserve(params.size());
   for (const auto& param : params) {
-    io_params.push_back(param.get_name());
-    io_stats[param.get_name()] = 0;
-    io_max_stats[param.get_name()] = 0;
+    io_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
   }
 }
 
 void iomon::update_stats(const std::vector<pid_t>& pids) {
+  prmon::monitored_value_map io_stat_update{};
+  for (const auto& value : io_stats) {
+    io_stat_update[value.first] = 0L;
+  }
+
   std::string param{};
-  unsigned long long value{};
-  for (auto& stat : io_stats) stat.second = 0;
-  // Loop over each PID and update the stats which are stored for all children
+  prmon::mon_value value{};
   for (const auto pid : pids) {
     std::stringstream io_fname{};
     io_fname << "/proc/" << pid << "/io" << std::ends;
@@ -42,65 +42,55 @@ void iomon::update_stats(const std::vector<pid_t>& pids) {
       proc_io >> param >> value;
       if (proc_io && param.size() > 0) {
         param.erase(param.size() - 1);  // Chop off training ":"
-        auto element = io_stats.find(param);
-        if (element != io_stats.end()) element->second += value;
+        auto element = io_stat_update.find(param);
+        if (element != io_stat_update.end()) element->second += value;
       }
     }
   }
 
 #if IOMON_TEST == 1
   long stat_counter = 0;
-#endif
 
-  for (auto& stat : io_stats) {
+  for (auto& stat : io_stat_update) {
     // This code block randomly suppresses io stat values
     // to test recovery from the peak measured values
-#if IOMON_TEST == 1
-    if (log_level <= spdlog::level::debug) {
-      auto t = time(NULL);
-      auto m = (t + stat_counter) % 4;
-      std::stringstream strm;
-      strm << stat_counter << " " << t << " " << m << std::endl;
-      debug(strm.str());
-      if (m == 0) stat.second = 0;
-      ++stat_counter;
-    }
-#endif
-    if (stat.second < io_max_stats[stat.first]) {
-      // Uh oh - somehow the i/o stats dropped so some i/o was lost
-      if (log_level <= spdlog::level::warn) {
-        std::stringstream strm;
-        strm << "prmon: Warning, detected drop in i/o values for " << stat.first
-             << " (" << io_max_stats[stat.first] << " became " << stat.second
-             << ")" << std::endl;
-        warning(strm.str());
-      }
-      stat.second = io_max_stats[stat.first];
-    } else {
-      io_max_stats[stat.first] = stat.second;
-    }
+    auto t = time(NULL);
+    auto m = (t + stat_counter) % 4;
+    std::stringstream strm;
+    strm << stat_counter << " " << t << " " << m;
+    debug(strm.str());
+    if (m == 0) stat.second = 0;
+    ++stat_counter;
   }
+#endif
+
+  for (auto& value : io_stats)
+    value.second.set_value(io_stat_update[value.first]);
 }
 
 // Return the counters
-std::map<std::string, unsigned long long> const iomon::get_text_stats() {
-  return io_stats;
+prmon::monitored_value_map const iomon::get_text_stats() {
+  prmon::monitored_value_map io_stat_map{};
+  for (const auto& value : io_stats) {
+    io_stat_map[value.first] = value.second.get_value();
+  }
+  return io_stat_map;
 }
 
 // Same for JSON
-std::map<std::string, unsigned long long> const iomon::get_json_total_stats() {
-  return io_stats;
+prmon::monitored_value_map const iomon::get_json_total_stats() {
+  return get_text_stats();
 }
 
 // For JSON averages, divide by elapsed time
-std::map<std::string, double> const iomon::get_json_average_stats(
+prmon::monitored_average_map const iomon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, double> json_average_stats{};
+  prmon::monitored_average_map io_average_stats{};
   for (const auto& io_param : io_stats) {
-    json_average_stats[io_param.first] =
-        double(io_param.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
+    io_average_stats[io_param.first] =
+        double(io_param.second.get_value() * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
   }
-  return json_average_stats;
+  return io_average_stats;
 }
 
 // Collect related hardware information

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -23,15 +23,10 @@ class iomon final : public Imonitor, public MessageBase {
                                         {"read_bytes", "B", "B/s"},
                                         {"write_bytes", "B", "B/s"}};
 
-  // Which network io paramters to measure and output key names
-  std::vector<std::string> io_params;
-
-  // Container for stats, one container that holds
-  // the current stats and a backup container for
-  // maximum values, in case the process tree loses some
-  // i/o values (see Github #173)
-  std::map<std::string, unsigned long long> io_stats;
-  std::map<std::string, unsigned long long> io_max_stats;
+  // Dynamic monitoring container for value measurements
+  // This will be filled at initialisation, taking the names
+  // from the above params
+  prmon::monitored_list io_stats;
 
  public:
   iomon();
@@ -39,9 +34,9 @@ class iomon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  std::map<std::string, unsigned long long> const get_text_stats();
-  std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(
+  prmon::monitored_value_map const get_text_stats();
+  prmon::monitored_value_map const get_json_total_stats();
+  prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -22,7 +22,8 @@ memmon::memmon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    mem_stats.emplace(std::make_pair(param.get_name(), prmon::monitored_value(param)));
+    mem_stats.emplace(
+        std::make_pair(param.get_name(), prmon::monitored_value(param)));
   }
 }
 

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -22,8 +22,7 @@ memmon::memmon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    mem_stats.emplace(
-        std::make_pair(param.get_name(), prmon::monitored_value(param)));
+    mem_stats.emplace(param.get_name(), prmon::monitored_value(param));
   }
 }
 

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 // Memory monitoring class
@@ -26,17 +26,10 @@ class memmon final : public Imonitor, public MessageBase {
                                         {"rss", "kB", "kB"},
                                         {"swap", "kB", "kB"}};
 
-  // Which network memory parameters to measure and output key names
-  std::vector<std::string> mem_params;
-
-  // Container for total stats
-  std::map<std::string, unsigned long long> mem_stats;
-  std::map<std::string, unsigned long long> mem_peak_stats;
-  std::map<std::string, double> mem_average_stats;
-  std::map<std::string, unsigned long long> mem_total_stats;
-
-  // Counter for number of iterations
-  unsigned long iterations;
+  // Dynamic monitoring container for value measurements
+  // This will be filled at initialisation, taking the names
+  // from the above params
+  prmon::monitored_list mem_stats;
 
  public:
   memmon();

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -89,7 +89,6 @@ void netmon::read_raw_network_stats(prmon::monitored_value_map& stats) {
     for (const auto& device : monitored_netdevs) {
       network_if_streams[if_param][device]->seekg(0);
       *network_if_streams[if_param][device] >> value_read;
-      // debug(if_param + " " *)
       stats[if_param] += value_read;
     }
   }
@@ -123,7 +122,7 @@ std::map<std::string, unsigned long long> const netmon::get_json_total_stats() {
 prmon::monitored_average_map const netmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   prmon::monitored_average_map json_average_stats{};
-  for (auto& value : net_stats) {
+  for (const auto& value : net_stats) {
     json_average_stats[value.first] =
         double(value.second.get_value() * sysconf(_SC_CLK_TCK)) /
         elapsed_clock_ticks;

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -34,10 +34,10 @@ netmon::netmon(std::vector<std::string> netdevs)
   // Ensure internal stat counters are initialised properly
   read_raw_network_stats(network_stats_initial);
   for (const auto& param : params) {
-    net_stats.emplace(std::make_pair(
+    net_stats.emplace(
         param.get_name(),
         prmon::monitored_value(param, true,
-                               network_stats_initial[param.get_name()])));
+                               network_stats_initial[param.get_name()]));
   }
 }
 

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 #include "netmon.h"
@@ -32,10 +32,12 @@ netmon::netmon(std::vector<std::string> netdevs)
   open_interface_streams();
 
   // Ensure internal stat counters are initialised properly
-  read_raw_network_stats(network_stats_last);
-  for (const auto& i : network_stats_last) {
-    network_net_counters[i.first] = 0;
+  read_raw_network_stats(network_stats_initial);
+  for (const auto& param : params) {
+    net_stats.emplace(std::make_pair(param.get_name(), 
+      prmon::monitored_value(param, true, network_stats_initial[param.get_name()])));
   }
+
 }
 
 // Get all available network devices
@@ -79,14 +81,14 @@ void netmon::open_interface_streams() {
 }
 
 // Read raw stat values
-void netmon::read_raw_network_stats(
-    std::map<std::string, unsigned long long>& stats) {
+void netmon::read_raw_network_stats(prmon::monitored_value_map& stats) {
   for (const auto& if_param : interface_params) {
-    unsigned long long value_read{};
+    prmon::mon_value value_read{};
     stats[if_param] = 0;
     for (const auto& device : monitored_netdevs) {
       network_if_streams[if_param][device]->seekg(0);
       *network_if_streams[if_param][device] >> value_read;
+      //debug(if_param + " " *)
       stats[if_param] += value_read;
     }
   }
@@ -94,25 +96,21 @@ void netmon::read_raw_network_stats(
 
 // Update statistics
 void netmon::update_stats(const std::vector<pid_t>& pids) {
-  read_raw_network_stats(network_stats);
-  for (const auto& i : network_stats) {
-    if (i.second >= network_stats_last[i.first]) {
-      network_net_counters[i.first] += i.second - network_stats_last[i.first];
-    } else {
-      std::stringstream strm;
-      strm << "prmon: network statistics error, counter values dropped for "
-           << i.first << " (" << i.second << " < "
-           << network_stats_last[i.first] << ")" << std::endl;
-      warning(strm.str());
-    }
-    network_stats_last[i.first] = i.second;
+  prmon::monitored_value_map network_stats_update;
+
+  read_raw_network_stats(network_stats_update);
+  for (auto& value : net_stats) {
+    value.second.set_value(network_stats_update[value.first]);
   }
 }
 
 // Relative counter statistics for text file
-std::map<std::string, unsigned long long> const netmon::get_text_stats() {
-  std::map<std::string, unsigned long long> text_stats{};
-  return network_net_counters;
+prmon::monitored_value_map const netmon::get_text_stats() {
+  prmon::monitored_value_map net_stat_map{};
+  for (const auto& value : net_stats) {
+    net_stat_map[value.first] = value.second.get_value();
+  }
+  return net_stat_map;
 }
 
 // Also relative counters for JSON totals
@@ -121,12 +119,12 @@ std::map<std::string, unsigned long long> const netmon::get_json_total_stats() {
 }
 
 // For JSON averages, divide by elapsed time
-std::map<std::string, double> const netmon::get_json_average_stats(
+prmon::monitored_average_map const netmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
-  std::map<std::string, double> json_average_stats{};
-  for (auto& stat : network_net_counters) {
-    json_average_stats[stat.first] =
-        double(stat.second * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
+  prmon::monitored_average_map json_average_stats{};
+  for (auto& value : net_stats) {
+    json_average_stats[value.first] =
+        double(value.second.get_value() * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -34,10 +34,11 @@ netmon::netmon(std::vector<std::string> netdevs)
   // Ensure internal stat counters are initialised properly
   read_raw_network_stats(network_stats_initial);
   for (const auto& param : params) {
-    net_stats.emplace(std::make_pair(param.get_name(), 
-      prmon::monitored_value(param, true, network_stats_initial[param.get_name()])));
+    net_stats.emplace(std::make_pair(
+        param.get_name(),
+        prmon::monitored_value(param, true,
+                               network_stats_initial[param.get_name()])));
   }
-
 }
 
 // Get all available network devices
@@ -88,7 +89,7 @@ void netmon::read_raw_network_stats(prmon::monitored_value_map& stats) {
     for (const auto& device : monitored_netdevs) {
       network_if_streams[if_param][device]->seekg(0);
       *network_if_streams[if_param][device] >> value_read;
-      //debug(if_param + " " *)
+      // debug(if_param + " " *)
       stats[if_param] += value_read;
     }
   }
@@ -124,7 +125,8 @@ prmon::monitored_average_map const netmon::get_json_average_stats(
   prmon::monitored_average_map json_average_stats{};
   for (auto& value : net_stats) {
     json_average_stats[value.first] =
-        double(value.second.get_value() * sysconf(_SC_CLK_TCK)) / elapsed_clock_ticks;
+        double(value.second.get_value() * sysconf(_SC_CLK_TCK)) /
+        elapsed_clock_ticks;
   }
   return json_average_stats;
 }

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -114,7 +114,7 @@ prmon::monitored_value_map const netmon::get_text_stats() {
 }
 
 // Also relative counters for JSON totals
-std::map<std::string, unsigned long long> const netmon::get_json_total_stats() {
+prmon::monitored_value_map const netmon::get_json_total_stats() {
   return get_text_stats();
 }
 
@@ -124,7 +124,7 @@ prmon::monitored_average_map const netmon::get_json_average_stats(
   prmon::monitored_average_map json_average_stats{};
   for (const auto& value : net_stats) {
     json_average_stats[value.first] =
-        double(value.second.get_value() * sysconf(_SC_CLK_TCK)) /
+        prmon::avg_value(value.second.get_value() * sysconf(_SC_CLK_TCK)) /
         elapsed_clock_ticks;
   }
   return json_average_stats;

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -64,8 +64,7 @@ class netmon final : public Imonitor, public MessageBase {
   }
 
   // Internal method to read "raw" network stats
-  void read_raw_network_stats(
-      prmon::monitored_value_map& values);
+  void read_raw_network_stats(prmon::monitored_value_map& values);
 
  public:
   netmon(std::vector<std::string> netdevs);

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 // Network monitoring class
@@ -31,6 +31,14 @@ class netmon final : public Imonitor, public MessageBase {
                                         {"tx_bytes", "B", "B/s"},
                                         {"tx_packets", "1", "1/s"}};
 
+  // Dynamic monitoring container for value measurements
+  // This will be filled at initialisation, taking the names
+  // from the above params
+  prmon::monitored_list net_stats;
+
+  // Initial values, as these stats are global counters
+  prmon::monitored_value_map network_stats_initial;
+
   // Vector for network interface paramters to measure (will be constructed)
   std::vector<std::string> interface_params;
 
@@ -41,10 +49,6 @@ class netmon final : public Imonitor, public MessageBase {
   std::map<std::string,
            std::unordered_map<std::string, std::unique_ptr<std::ifstream>>>
       network_if_streams;
-
-  // Container for stats, initial and current
-  std::map<std::string, unsigned long long> network_stats, network_stats_last,
-      network_net_counters;
 
   // Find all network interfaces on the system
   std::vector<std::string> const get_all_network_devs();
@@ -61,7 +65,7 @@ class netmon final : public Imonitor, public MessageBase {
 
   // Internal method to read "raw" network stats
   void read_raw_network_stats(
-      std::map<std::string, unsigned long long>& values);
+      prmon::monitored_value_map& values);
 
  public:
   netmon(std::vector<std::string> netdevs);
@@ -70,9 +74,9 @@ class netmon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  std::map<std::string, unsigned long long> const get_text_stats();
-  std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(
+  prmon::monitored_value_map const get_text_stats();
+  prmon::monitored_value_map const get_json_total_stats();
+  prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once

--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -19,8 +19,7 @@ nvidiamon::nvidiamon() {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    nvidia_stats.emplace(
-        std::make_pair(param.get_name(), prmon::monitored_value(param)));
+    nvidia_stats.emplace(param.get_name(), prmon::monitored_value(param));
   }
 
   // Attempt to execute nvidia-smi

--- a/package/src/nvidiamon.h
+++ b/package/src/nvidiamon.h
@@ -24,17 +24,9 @@ class nvidiamon final : public Imonitor, public MessageBase {
                                         {"gpumempct", "%", "%"},
                                         {"gpufbmem", "kB", "kB"}};
 
-  // Which paramters to measure and output key names
-  std::vector<std::string> nvidia_params;
-
-  // Container for total stats
-  std::map<std::string, unsigned long long> nvidia_stats;
-  std::map<std::string, unsigned long long> nvidia_peak_stats;
-  std::map<std::string, double> nvidia_average_stats;
-  std::map<std::string, unsigned long long> nvidia_total_stats;
-
-  // Counter for number of iterations
-  unsigned long iterations;
+  // Map of classes that represent each monitored quantity
+  // Will be initialised from the above parameter list
+  prmon::monitored_list nvidia_stats;
 
   // Set a boolean to see if we have a valid nvidia setup
   bool valid;
@@ -55,9 +47,9 @@ class nvidiamon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  std::map<std::string, unsigned long long> const get_text_stats();
-  std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(
+  prmon::monitored_value_map const get_text_stats();
+  prmon::monitored_value_map const get_json_total_stats();
+  prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -7,13 +7,39 @@
 
 namespace prmon {
 int monitored_value::set_value(mon_value new_value) {
-  if (monotonic && (new_value < value)) {
-    std::cerr << "Error: attempt to reduce the monitored value of " << param.get_name()
-              << " (which is monotonic)" << std::endl;
-    return 1;
+  if (monotonic) {
+    // Monotonic values only increase and never have useful
+    // sums or average values based on iterations
+    if (new_value < value) {
+      std::cerr << "Error: attempt to reduce the monitored value of "
+              << param.get_name() << " (which is monotonic)" << std::endl;
+      return 1;
+    }
+    value = new_value;
+    max_value = new_value;
+  } else {
+    // Non-monotonic values can go up and down and have
+    // useful average values
+    value = new_value;
+    if (value > max_value) max_value = value;
+    summed_value += value;
+    ++iterations;
   }
-  value = new_value;
-  if (value > max_value) max_value = value;
   return 0;
 }
+
+prmon::mon_value const monitored_value::get_summed_value() const {
+  if (!monotonic) {
+    return summed_value;
+  }
+  return 0;
+}
+
+prmon::avg_value const monitored_value::get_average_value() const {
+  if ((!monotonic) && (iterations > 0)) {
+    return prmon::avg_value(summed_value) / iterations;
+  }
+  return 0;
+}
+
 }  // namespace prmon

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -7,6 +7,15 @@
 
 namespace prmon {
 int monitored_value::set_value(mon_value new_value) {
+  // If we have an offset for this parameter then passing in
+  // a set value less than this is illegal
+  if (new_value < offset) {
+    std::cerr << "Error: attempt to set value of " << param.get_name() <<
+    " to less than this parameter's offset of " << offset << std::endl;
+    return 1;
+  }
+  new_value -= offset;
+
   if (monotonic) {
     // Monotonic values only increase and never have useful
     // sums or average values based on iterations

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -10,8 +10,9 @@ int monitored_value::set_value(mon_value new_value) {
   // If we have an offset for this parameter then passing in
   // a set value less than this is illegal
   if (new_value < offset) {
-    std::cerr << "Error: attempt to set value of " << param.get_name() <<
-    " to less than this parameter's offset of " << offset << std::endl;
+    std::cerr << "Error: attempt to set value of " << param.get_name()
+              << " to less than this parameter's offset of " << offset
+              << std::endl;
     return 1;
   }
   new_value -= offset;
@@ -21,7 +22,7 @@ int monitored_value::set_value(mon_value new_value) {
     // sums or average values based on iterations
     if (new_value < value) {
       std::cerr << "Error: attempt to reduce the monitored value of "
-              << param.get_name() << " (which is monotonic)" << std::endl;
+                << param.get_name() << " (which is monotonic)" << std::endl;
       return 1;
     }
     value = new_value;

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -8,11 +8,12 @@
 namespace prmon {
 int monitored_value::set_value(mon_value new_value) {
   if (monotonic && (new_value < value)) {
-    std::cerr << "Error: attempt to reduce the monitored value of " << name
+    std::cerr << "Error: attempt to reduce the monitored value of " << param.get_name()
               << " (which is monotonic)" << std::endl;
     return 1;
   }
   value = new_value;
+  if (value > max_value) max_value = value;
   return 0;
 }
 }  // namespace prmon

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -1,17 +1,18 @@
 // Copyright (C) 2021 CERN
 // License Apache2 - see LICENCE file
 
-#include <iostream>
-
 #include "parameter.h"
 
+#include <iostream>
+
 namespace prmon {
-  int monitored_value::set_value(mon_value new_value) {
-    if (monotonic && (new_value < value)) {
-      std::cerr << "Error: attempt to reduce the monitored value of " << name << " (which is monotonic)" << std::endl;
-      return 1;
-    }
-    value = new_value;
-    return 0;
+int monitored_value::set_value(mon_value new_value) {
+  if (monotonic && (new_value < value)) {
+    std::cerr << "Error: attempt to reduce the monitored value of " << name
+              << " (which is monotonic)" << std::endl;
+    return 1;
   }
+  value = new_value;
+  return 0;
 }
+}  // namespace prmon

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 CERN
+// License Apache2 - see LICENCE file
+
+#include <iostream>
+
+#include "parameter.h"
+
+namespace prmon {
+  int monitored_value::set_value(mon_value new_value) {
+    if (monotonic && (new_value < value)) {
+      std::cerr << "Error: attempt to reduce the monitored value of " << name << " (which is monotonic)" << std::endl;
+      return 1;
+    }
+    value = new_value;
+    return 0;
+  }
+}

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -10,8 +10,11 @@ int monitored_value::set_value(mon_value new_value) {
   // If we have an offset for this parameter then passing in
   // a set value less than this is illegal
   if (new_value < offset) {
+    std::string s_offset = std::to_string(offset);
+    std::string s_new_value = std::to_string(new_value);
     spdlog::error("Error: attempt to set value of " + m_param.get_name() +
-                  " to less than this parameter's offset");
+                  " to " + s_new_value +
+                  ", less than this parameter's offset of " + s_offset);
     return 1;
   }
   new_value -= offset;
@@ -20,8 +23,11 @@ int monitored_value::set_value(mon_value new_value) {
     // Monotonic values only increase and never have useful
     // sums or average values based on iterations
     if (new_value < value) {
-      spdlog::error("Error: attempt to reduce the monitored value of " +
-                    m_param.get_name() + " (which is monotonic)");
+      std::string s_new_value = std::to_string(new_value);
+      std::string s_value = std::to_string(value);
+      spdlog::error(
+          "Error: attempt to reduce the monitored value of monotonic " +
+          m_param.get_name() + " from " + s_value + " to " + s_new_value);
       return 1;
     }
     value = new_value;

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -10,19 +10,19 @@ int monitored_value::set_value(mon_value new_value) {
   // If we have an offset for this parameter then passing in
   // a set value less than this is illegal
   if (new_value < offset) {
-    std::cerr << "Error: attempt to set value of " << param.get_name()
+    std::cerr << "Error: attempt to set value of " << m_param.get_name()
               << " to less than this parameter's offset of " << offset
               << std::endl;
     return 1;
   }
   new_value -= offset;
 
-  if (monotonic) {
+  if (m_monotonic) {
     // Monotonic values only increase and never have useful
     // sums or average values based on iterations
     if (new_value < value) {
       std::cerr << "Error: attempt to reduce the monitored value of "
-                << param.get_name() << " (which is monotonic)" << std::endl;
+                << m_param.get_name() << " (which is monotonic)" << std::endl;
       return 1;
     }
     value = new_value;
@@ -33,7 +33,7 @@ int monitored_value::set_value(mon_value new_value) {
     value = new_value;
     if (value > max_value) max_value = value;
     summed_value += value;
-    ++iterations;
+    ++m_iterations;
   }
   return 0;
 }
@@ -42,7 +42,7 @@ int monitored_value::set_offset(mon_value const new_offset) {
   // It is only valid to apply this function when no iterations
   // have been made!
   offset = new_offset;
-  if (iterations > 0) {
+  if (m_iterations > 0) {
     std::cerr << "Resetting the offset of measured values is dangerous"
               << std::endl;
     return 1;
@@ -51,15 +51,15 @@ int monitored_value::set_offset(mon_value const new_offset) {
 }
 
 prmon::mon_value const monitored_value::get_summed_value() const {
-  if (!monotonic) {
+  if (!m_monotonic) {
     return summed_value;
   }
   return 0;
 }
 
 prmon::avg_value const monitored_value::get_average_value() const {
-  if ((!monotonic) && (iterations > 0)) {
-    return prmon::avg_value(summed_value) / iterations;
+  if ((!m_monotonic) && (m_iterations > 0)) {
+    return prmon::avg_value(summed_value) / m_iterations;
   }
   return 0;
 }

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -38,6 +38,18 @@ int monitored_value::set_value(mon_value new_value) {
   return 0;
 }
 
+int monitored_value::set_offset(mon_value const new_offset) {
+  // It is only valid to apply this function when no iterations
+  // have been made!
+  offset = new_offset;
+  if (iterations > 0) {
+    std::cerr << "Resetting the offset of measured values is dangerous"
+              << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
 prmon::mon_value const monitored_value::get_summed_value() const {
   if (!monotonic) {
     return summed_value;

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -10,9 +10,8 @@ int monitored_value::set_value(mon_value new_value) {
   // If we have an offset for this parameter then passing in
   // a set value less than this is illegal
   if (new_value < offset) {
-    std::cerr << "Error: attempt to set value of " << m_param.get_name()
-              << " to less than this parameter's offset of " << offset
-              << std::endl;
+    spdlog::error("Error: attempt to set value of " + m_param.get_name() +
+                  " to less than this parameter's offset");
     return 1;
   }
   new_value -= offset;
@@ -21,8 +20,8 @@ int monitored_value::set_value(mon_value new_value) {
     // Monotonic values only increase and never have useful
     // sums or average values based on iterations
     if (new_value < value) {
-      std::cerr << "Error: attempt to reduce the monitored value of "
-                << m_param.get_name() << " (which is monotonic)" << std::endl;
+      spdlog::error("Error: attempt to reduce the monitored value of " +
+                    m_param.get_name() + " (which is monotonic)");
       return 1;
     }
     value = new_value;
@@ -43,8 +42,8 @@ int monitored_value::set_offset(mon_value const new_offset) {
   // have been made!
   offset = new_offset;
   if (m_iterations > 0) {
-    std::cerr << "Resetting the offset of measured values is dangerous"
-              << std::endl;
+    spdlog::warn("Resetting the offset of measured values is dangerous (" +
+                 m_param.get_name() + ")");
     return 1;
   }
   return 0;

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 // Monitored quantity class

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 #ifndef PRMON_PARAMETER_H
 #define PRMON_PARAMETER_H 1
@@ -50,10 +51,6 @@ class monitored_value {
   mon_value value;
 
  public:
-  monitored_value(std::string n, std::string m, std::string a,
-                  mon_value start = 0L)
-      : name{n}, max_unit{m}, avg_unit{a}, value{start} {}
-
   inline const std::string get_name() const { return name; }
   inline const std::string get_max_unit() const { return max_unit; }
   inline const std::string get_avg_unit() const { return avg_unit; }
@@ -61,9 +58,13 @@ class monitored_value {
   inline const mon_value get_value() const { return value; }
 
   int set_value(mon_value new_value);
+
+  monitored_value(std::string n, std::string m, std::string a, bool mono=false,
+                  mon_value start = 0L)
+      : name{n}, max_unit{m}, avg_unit{a}, monotonic{mono}, value{start} {}
 };
 
-using monitored_list = std::map<std::string, monitored_value>;
+using monitored_list = std::map<std::string, prmon::monitored_value>;
 
 }  // namespace prmon
 

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "spdlog/spdlog.h"
+
 #ifndef PRMON_PARAMETER_H
 #define PRMON_PARAMETER_H 1
 

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -72,6 +72,7 @@ class monitored_value {
   // set_value() should be called with the "raw" value and the monitor
   // will itself apply any offset needed
   int set_value(mon_value new_value);
+  int set_offset(mon_value new_offset);
 
   monitored_value(std::string n, std::string m, std::string a,
                   bool mono = false, mon_value offset = 0L)

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -51,9 +51,12 @@ class monitored_value {
 
   bool monotonic;
   unsigned long iterations;
+
+  // All internal values will be stored with any offset applied
   mon_value value;
   mon_value max_value;
   mon_value summed_value;
+  mon_value offset;
 
  public:
   inline const std::string get_name() const { return param.get_name(); }
@@ -64,25 +67,30 @@ class monitored_value {
   inline const mon_value get_max_value() const { return max_value; }
   const mon_value get_summed_value() const;
   const avg_value get_average_value() const;
+  inline const mon_value get_offset() const { return offset; }
 
+  // set_value() should be called with the "raw" value and the monitor
+  // will itself apply any offset needed
   int set_value(mon_value new_value);
 
   monitored_value(std::string n, std::string m, std::string a,
-                  bool mono = false, mon_value start = 0L)
+                  bool mono = false, mon_value offset = 0L)
       : param{n, m, a},
         monotonic{mono},
         iterations{0},
-        value{start},
-        max_value{start},
-        summed_value{start} {}
+        value{offset},
+        max_value{offset},
+        summed_value{0L},
+        offset{offset} {}
 
-  monitored_value(parameter p, bool mono = false, mon_value start = 0L)
+  monitored_value(parameter p, bool mono = false, mon_value offset = 0L)
       : param{p},
         monotonic{mono},
         iterations{0},
-        value{start},
-        max_value{start},
-        summed_value{start} {}
+        value{offset},
+        max_value{offset},
+        summed_value{0L},
+        offset{offset} {}
 };
 
 using monitored_list = std::map<std::string, prmon::monitored_value>;

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -60,8 +60,12 @@ class monitored_value {
 
  public:
   inline const std::string get_name() const { return m_param.get_name(); }
-  inline const std::string get_max_unit() const { return m_param.get_max_unit(); }
-  inline const std::string get_avg_unit() const { return m_param.get_avg_unit(); }
+  inline const std::string get_max_unit() const {
+    return m_param.get_max_unit();
+  }
+  inline const std::string get_avg_unit() const {
+    return m_param.get_avg_unit();
+  }
 
   inline const mon_value get_value() const { return value; }
   inline const mon_value get_max_value() const { return max_value; }

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -47,10 +47,10 @@ class monitored_value {
   // as well as internal counters and accessors. In particular the monotonic
   // flag will prevent the measured value from being lowered.
  private:
-  const parameter param;
+  const parameter m_param;
 
-  bool monotonic;
-  unsigned long iterations;
+  bool m_monotonic;
+  unsigned long m_iterations;
 
   // All internal values will be stored with any offset applied
   mon_value value;
@@ -59,9 +59,9 @@ class monitored_value {
   mon_value offset;
 
  public:
-  inline const std::string get_name() const { return param.get_name(); }
-  inline const std::string get_max_unit() const { return param.get_max_unit(); }
-  inline const std::string get_avg_unit() const { return param.get_avg_unit(); }
+  inline const std::string get_name() const { return m_param.get_name(); }
+  inline const std::string get_max_unit() const { return m_param.get_max_unit(); }
+  inline const std::string get_avg_unit() const { return m_param.get_avg_unit(); }
 
   inline const mon_value get_value() const { return value; }
   inline const mon_value get_max_value() const { return max_value; }
@@ -76,18 +76,18 @@ class monitored_value {
 
   monitored_value(std::string n, std::string m, std::string a,
                   bool mono = false, mon_value offset = 0L)
-      : param{n, m, a},
-        monotonic{mono},
-        iterations{0},
+      : m_param{n, m, a},
+        m_monotonic{mono},
+        m_iterations{0},
         value{0L},
         max_value{0L},
         summed_value{0L},
         offset{offset} {}
 
   monitored_value(parameter p, bool mono = false, mon_value offset = 0L)
-      : param{p},
-        monotonic{mono},
-        iterations{0},
+      : m_param{p},
+        m_monotonic{mono},
+        m_iterations{0},
         value{0L},
         max_value{0L},
         summed_value{0L},

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -28,16 +28,16 @@ using monitored_average_map = std::map<std::string, avg_value>;
 // adding that informtion to the JSON output file
 class parameter {
  private:
-  std::string name;
-  std::string max_unit, avg_unit;
+  std::string m_name;
+  std::string m_max_unit, m_avg_unit;
 
  public:
-  inline const std::string get_name() const { return name; }
-  inline const std::string get_max_unit() const { return max_unit; }
-  inline const std::string get_avg_unit() const { return avg_unit; }
+  inline const std::string get_name() const { return m_name; }
+  inline const std::string get_max_unit() const { return m_max_unit; }
+  inline const std::string get_avg_unit() const { return m_avg_unit; }
 
   parameter(std::string n, std::string m, std::string a)
-      : name{n}, max_unit{m}, avg_unit{a} {}
+      : m_name{n}, m_max_unit{m}, m_avg_unit{a} {}
 };
 
 using parameter_list = std::vector<parameter>;
@@ -55,10 +55,10 @@ class monitored_value {
   unsigned long m_iterations;
 
   // All internal values will be stored with any offset applied
-  mon_value value;
-  mon_value max_value;
-  mon_value summed_value;
-  mon_value offset;
+  mon_value m_value;
+  mon_value m_max_value;
+  mon_value m_summed_value;
+  mon_value m_offset;
 
  public:
   inline const std::string get_name() const { return m_param.get_name(); }
@@ -69,35 +69,25 @@ class monitored_value {
     return m_param.get_avg_unit();
   }
 
-  inline const mon_value get_value() const { return value; }
-  inline const mon_value get_max_value() const { return max_value; }
+  inline const mon_value get_value() const { return m_value; }
+  inline const mon_value get_max_value() const { return m_max_value; }
   const mon_value get_summed_value() const;
   const avg_value get_average_value() const;
-  inline const mon_value get_offset() const { return offset; }
+  inline const mon_value get_offset() const { return m_offset; }
 
   // set_value() should be called with the "raw" value and the monitor
   // will itself apply any offset needed
   int set_value(mon_value new_value);
   int set_offset(mon_value new_offset);
 
-  monitored_value(std::string n, std::string m, std::string a,
-                  bool mono = false, mon_value offset = 0L)
-      : m_param{n, m, a},
-        m_monotonic{mono},
-        m_iterations{0},
-        value{0L},
-        max_value{0L},
-        summed_value{0L},
-        offset{offset} {}
-
   monitored_value(parameter p, bool mono = false, mon_value offset = 0L)
       : m_param{p},
         m_monotonic{mono},
         m_iterations{0},
-        value{0L},
-        max_value{0L},
-        summed_value{0L},
-        offset{offset} {}
+        m_value{0L},
+        m_max_value{0L},
+        m_summed_value{0L},
+        m_offset{offset} {}
 };
 
 using monitored_list = std::map<std::string, prmon::monitored_value>;

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -78,8 +78,8 @@ class monitored_value {
       : param{n, m, a},
         monotonic{mono},
         iterations{0},
-        value{offset},
-        max_value{offset},
+        value{0L},
+        max_value{0L},
         summed_value{0L},
         offset{offset} {}
 
@@ -87,8 +87,8 @@ class monitored_value {
       : param{p},
         monotonic{mono},
         iterations{0},
-        value{offset},
-        max_value{offset},
+        value{0L},
+        max_value{0L},
         summed_value{0L},
         offset{offset} {}
 };

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -9,6 +9,10 @@
 #ifndef PRMON_PARAMETER_H
 #define PRMON_PARAMETER_H 1
 
+// Define here the types we use for each monitoring primitive
+using mon_value = unsigned long long;
+using avg_value = double;
+
 namespace prmon {
 // parameter class holds three strings for each monitored value:
 // - the name of the value
@@ -31,6 +35,36 @@ class parameter {
 };
 
 using parameter_list = std::vector<parameter>;
+
+class monitored_value {
+  // monitored_value class gives an interface to a value that we monitor
+  // in prmon
+  // It holds metadata about the value (name, units) as well as internal
+  // counters and accessors. In particular the monotonic flag will prevent
+  // the measured value from being lowered.
+ private:
+  std::string name;
+  std::string max_unit, avg_unit;
+
+  bool monotonic;
+  mon_value value;
+
+ public:
+  monitored_value(std::string n, std::string m, std::string a,
+                  mon_value start = 0L)
+      : name{n}, max_unit{m}, avg_unit{a}, value{start} {}
+
+  inline const std::string get_name() const { return name; }
+  inline const std::string get_max_unit() const { return max_unit; }
+  inline const std::string get_avg_unit() const { return avg_unit; }
+
+  inline const mon_value get_value() const { return value; }
+
+  int set_value(mon_value new_value);
+};
+
+using monitored_list = std::map<std::string, monitored_value>;
+
 }  // namespace prmon
 
 #endif  // PRMON_PARAMETER_H

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -3,9 +3,9 @@
 
 // Monitored quantity class
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 #ifndef PRMON_PARAMETER_H
 #define PRMON_PARAMETER_H 1
@@ -40,28 +40,30 @@ using parameter_list = std::vector<parameter>;
 class monitored_value {
   // monitored_value class gives an interface to a value that we monitor
   // in prmon
-  // It holds metadata about the value (name, units) as well as internal
-  // counters and accessors. In particular the monotonic flag will prevent
-  // the measured value from being lowered.
+  // It holds metadata about the value (name, units - using the parameter class)
+  // as well as internal counters and accessors. In particular the monotonic
+  // flag will prevent the measured value from being lowered.
  private:
-  std::string name;
-  std::string max_unit, avg_unit;
+  const parameter param;
 
   bool monotonic;
   mon_value value;
 
  public:
-  inline const std::string get_name() const { return name; }
-  inline const std::string get_max_unit() const { return max_unit; }
-  inline const std::string get_avg_unit() const { return avg_unit; }
+  inline const std::string get_name() const { return param.get_name(); }
+  inline const std::string get_max_unit() const { return param.get_max_unit(); }
+  inline const std::string get_avg_unit() const { return param.get_avg_unit(); }
 
   inline const mon_value get_value() const { return value; }
 
   int set_value(mon_value new_value);
 
-  monitored_value(std::string n, std::string m, std::string a, bool mono=false,
-                  mon_value start = 0L)
-      : name{n}, max_unit{m}, avg_unit{a}, monotonic{mono}, value{start} {}
+  monitored_value(std::string n, std::string m, std::string a,
+                  bool mono = false, mon_value start = 0L)
+      : param{n, m, a}, monotonic{mono}, value{start} {}
+
+  monitored_value(parameter p, bool mono = false, mon_value start = 0L)
+      : param{p}, monotonic{mono}, value{start} {}
 };
 
 using monitored_list = std::map<std::string, prmon::monitored_value>;

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -50,8 +50,10 @@ class monitored_value {
   const parameter param;
 
   bool monotonic;
+  unsigned long iterations;
   mon_value value;
   mon_value max_value;
+  mon_value summed_value;
 
  public:
   inline const std::string get_name() const { return param.get_name(); }
@@ -60,15 +62,27 @@ class monitored_value {
 
   inline const mon_value get_value() const { return value; }
   inline const mon_value get_max_value() const { return max_value; }
+  const mon_value get_summed_value() const;
+  const avg_value get_average_value() const;
 
   int set_value(mon_value new_value);
 
   monitored_value(std::string n, std::string m, std::string a,
                   bool mono = false, mon_value start = 0L)
-      : param{n, m, a}, monotonic{mono}, value{start} {}
+      : param{n, m, a},
+        monotonic{mono},
+        iterations{0},
+        value{start},
+        max_value{start},
+        summed_value{start} {}
 
   monitored_value(parameter p, bool mono = false, mon_value start = 0L)
-      : param{p}, monotonic{mono}, value{start} {}
+      : param{p},
+        monotonic{mono},
+        iterations{0},
+        value{start},
+        max_value{start},
+        summed_value{start} {}
 };
 
 using monitored_list = std::map<std::string, prmon::monitored_value>;

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -10,11 +10,14 @@
 #ifndef PRMON_PARAMETER_H
 #define PRMON_PARAMETER_H 1
 
+namespace prmon {
 // Define here the types we use for each monitoring primitive
 using mon_value = unsigned long long;
 using avg_value = double;
 
-namespace prmon {
+using monitored_value_map = std::map<std::string, mon_value>;
+using monitored_average_map = std::map<std::string, avg_value>;
+
 // parameter class holds three strings for each monitored value:
 // - the name of the value
 // - the units of the value for maxiumums and averages
@@ -48,6 +51,7 @@ class monitored_value {
 
   bool monotonic;
   mon_value value;
+  mon_value max_value;
 
  public:
   inline const std::string get_name() const { return param.get_name(); }
@@ -55,6 +59,7 @@ class monitored_value {
   inline const std::string get_avg_unit() const { return param.get_avg_unit(); }
 
   inline const mon_value get_value() const { return value; }
+  inline const mon_value get_max_value() const { return max_value; }
 
   int set_value(mon_value new_value);
 

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -20,8 +20,8 @@ wallmon::wallmon() : got_mother_starttime{false} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
-    walltime_stats.emplace(
-        std::make_pair(param.get_name(), prmon::monitored_value(param, true)));
+    walltime_stats.emplace(param.get_name(),
+                           prmon::monitored_value(param, true));
   }
 }
 

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2021 CERN
 // License Apache2 - see LICENCE file
 
 // Wall time monitoring class
@@ -24,17 +24,15 @@ class wallmon final : public Imonitor, public MessageBase {
  private:
   const prmon::parameter_list params = {{"wtime", "s", ""}};
 
-  std::vector<std::string> walltime_param;
-
-  // Container for total stat
-  std::map<std::string, unsigned long long> walltime_stats;
+  // "map" of monitored parameters (even if there's only one!)
+  prmon::monitored_list walltime_stats;
 
   unsigned long long start_time_clock_t, current_clock_t;
 
   // Only need to get the mother start time once, so use
   // a bool to say when it's done
   bool got_mother_starttime;
-  int get_mother_starttime(pid_t mother_pid);
+  std::pair<int, unsigned long long> get_mother_starttime(pid_t mother_pid);
 
  public:
   wallmon();
@@ -42,9 +40,9 @@ class wallmon final : public Imonitor, public MessageBase {
   void update_stats(const std::vector<pid_t>& pids);
 
   // These are the stat getter methods which retrieve current statistics
-  std::map<std::string, unsigned long long> const get_text_stats();
-  std::map<std::string, unsigned long long> const get_json_total_stats();
-  std::map<std::string, double> const get_json_average_stats(
+  prmon::monitored_value_map const get_text_stats();
+  prmon::monitored_value_map const get_json_total_stats();
+  prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
 
   // This is the hardware information getter that runs once

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -20,7 +20,22 @@ if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_GTESTS)
     FetchContent_MakeAvailable(googletest)
     enable_testing()
 
+    add_executable(test_parameter_classes test_parameter_classes.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/parameter.cpp
+    )
+    target_include_directories(test_parameter_classes PRIVATE 
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    )
+    target_link_libraries(test_parameter_classes
+                            PRIVATE
+                            Threads::Threads
+                            gtest_main
+    )
+
     include(GoogleTest)
+    gtest_discover_tests(test_parameter_classes)
 
 endif()
 

--- a/package/tests/README.md
+++ b/package/tests/README.md
@@ -1,8 +1,13 @@
 # Tests README
 
-## Test model
+## Integration Tests
 
 - Standalone binaries provide executables that `prmon` can test
 	- e.g., `io-burner` and `mem-burner` 
 - Python scripts invoke these binaries and get `prmon` to monitor them, checking that the output is as expected
 	- Model is to use xUnit style of testing, with the normal python `unittest` module 
+
+## Unit Tests
+
+- Standalong binaries that utilise the Google Test infrastruture to test specific aspects of the code. These are only built if the CMake option `BUILD_GTESTS` is set to `ON`
+	- e.g. `test_parameter_classes`

--- a/package/tests/test_parameter_classes.cpp
+++ b/package/tests/test_parameter_classes.cpp
@@ -1,0 +1,111 @@
+// Unit tests for parameter classes in parameter.h
+
+#include <string>
+
+#include "../src/parameter.h"
+#include "gtest/gtest.h"
+
+const std::string param_name{"TestValue"};
+const std::string param_unit{"MegaFloops"};
+const std::string param_avg_unit{"MegaFloops/s"};
+
+// Simple test of parameter class
+TEST(ParameterClass, InitAndGetValues) {
+  prmon::parameter test_param{param_name, param_unit, param_avg_unit};
+
+  EXPECT_EQ(test_param.get_name(), param_name);
+  EXPECT_EQ(test_param.get_max_unit(), param_unit);
+  EXPECT_EQ(test_param.get_avg_unit(), param_avg_unit);
+}
+
+// Fixture class to define some different class instances for testing
+class MoitoredValueClassTest : public ::testing::Test {
+ protected:
+  // void SetUp() override {}
+  // void TearDown() override {}
+
+  const prmon::mon_value value1{668};
+  const prmon::mon_value value2{670};
+  const prmon::mon_value value3{662};
+
+  const prmon::mon_value offset{665};
+
+  prmon::parameter test_param{param_name, param_unit, param_avg_unit};
+  prmon::monitored_value test_value{test_param};
+  prmon::monitored_value test_mono_value{test_param, true};
+  prmon::monitored_value test_offset_value{test_param, false, offset};
+  prmon::monitored_value test_mono_offset_value{test_param, true, offset};
+};
+
+// Test basic setup of monitored_value
+TEST_F(MoitoredValueClassTest, InitAndGetValues) {
+  EXPECT_EQ(test_value.get_name(), param_name);
+  EXPECT_EQ(test_value.get_max_unit(), param_unit);
+  EXPECT_EQ(test_value.get_avg_unit(), param_avg_unit);
+}
+
+// Normal parameter, which can go up and down
+TEST_F(MoitoredValueClassTest, SetNormalValues) {
+  EXPECT_EQ(test_value.set_value(value1), 0);
+  EXPECT_EQ(test_value.get_value(), value1);
+
+  EXPECT_EQ(test_value.set_value(value2), 0);
+  EXPECT_EQ(test_value.get_value(), value2);
+
+  EXPECT_EQ(test_value.set_value(value3), 0);
+  EXPECT_EQ(test_value.get_value(), value3);
+
+  EXPECT_EQ(test_value.get_max_value(), value2);
+  EXPECT_EQ(test_value.get_summed_value(), value1 + value2 + value3);
+  EXPECT_EQ(test_value.get_average_value(),
+            prmon::avg_value(value1 + value2 + value3) / 3);
+}
+
+// Monotonic paramater, cannot go down
+TEST_F(MoitoredValueClassTest, SetMonoValues) {
+  EXPECT_EQ(test_mono_value.set_value(value1), 0);
+  EXPECT_EQ(test_mono_value.get_value(), value1);
+
+  EXPECT_EQ(test_mono_value.set_value(value2), 0);
+  EXPECT_EQ(test_mono_value.get_value(), value2);
+
+  EXPECT_EQ(test_mono_value.set_value(value3), 1);
+  EXPECT_EQ(test_mono_value.get_value(), value2);
+
+  EXPECT_EQ(test_mono_value.get_max_value(), value2);
+  EXPECT_EQ(test_mono_value.get_summed_value(), 0);
+  EXPECT_EQ(test_mono_value.get_average_value(), 0);
+}
+
+// Normal value, with an offset
+TEST_F(MoitoredValueClassTest, SetOffsetValues) {
+  EXPECT_EQ(test_offset_value.set_value(value1), 0);
+  EXPECT_EQ(test_offset_value.get_value(), value1 - offset);
+
+  EXPECT_EQ(test_offset_value.set_value(value2), 0);
+  EXPECT_EQ(test_offset_value.get_value(), value2 - offset);
+
+  EXPECT_EQ(test_offset_value.set_value(value3), 1);
+  EXPECT_EQ(test_offset_value.get_value(), value2 - offset);
+
+  EXPECT_EQ(test_offset_value.get_max_value(), value2 - offset);
+  EXPECT_EQ(test_offset_value.get_summed_value(), value1 + value2 - 2 * offset);
+  EXPECT_EQ(test_offset_value.get_average_value(),
+            prmon::avg_value(value1 + value2 - 2 * offset) / 2);
+}
+
+// Monotonic, with an offset
+TEST_F(MoitoredValueClassTest, SetMonoOffsetValues) {
+  EXPECT_EQ(test_mono_offset_value.set_value(value1), 0);
+  EXPECT_EQ(test_mono_offset_value.get_value(), value1 - offset);
+
+  EXPECT_EQ(test_mono_offset_value.set_value(value2), 0);
+  EXPECT_EQ(test_mono_offset_value.get_value(), value2 - offset);
+
+  EXPECT_EQ(test_mono_offset_value.set_value(value3), 1);
+  EXPECT_EQ(test_mono_offset_value.get_value(), value2 - offset);
+
+  EXPECT_EQ(test_mono_offset_value.get_max_value(), value2 - offset);
+  EXPECT_EQ(test_mono_offset_value.get_summed_value(), 0);
+  EXPECT_EQ(test_mono_offset_value.get_average_value(), 0);
+}


### PR DESCRIPTION
This is a big PR, as it introduces a specific class that handles monitored variables, thus refactoring of all monitors to use this class has been added. Also added are namespace `using` statements that define properly the types used by monitors.

The big advantages of this are:
- The intelligent handling of monitored values becomes part of the class, thus less specific code to catch errors needs to be added in each monitor itself
- Specifically values can be flagged as *monotonic*, which protects them against ever decreasing
- Data members and return types now use properly namespaced definitions

This enabled specific monitor protections for decreased values to be removed from a few monitors (iomon, netmon) as well as adding protection for CPU and walltime monitors.

Note that the class does not yet use loggers, but that this should be added (e.g., as a pointer to the logger instance, with `nullptr` meaning fallback to `std::cerr`).

Closes #185 