### PR TITLE
Integrate GoogleTest framework for unit tests

### DIFF
--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -18,7 +18,7 @@ if [ -z "$CMAKE" ]; then
 fi
 
 # For debugging, handy to print what we're doing
-cmd="$CMAKE -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC $CMAKE_EXTRA /mnt"
+cmd="$CMAKE -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_GTESTS=ON $CMAKE_EXTRA /mnt"
 echo $cmd
 $cmd
 make -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,10 @@ endif()
 set(BUILD_BENCHMARK_LOG "${BUILD_BENCHMARK_LOG}"
   CACHE BOOL "Build binary that benchmarks spdlog speed" FORCE)
 
-if(NOT BUILD_TEST_VALUES)
-  set(BUILD_TEST_VALUES OFF)
+if(NOT BUILD_GTESTS)
+  set(BUILD_GTESTS OFF)
 endif()
-set(BUILD_TEST_VALUES "${BUILD_TEST_VALUES}"
+set(BUILD_GTESTS "${BUILD_GTESTS}"
   CACHE BOOL "Add the value tests (dependent on gtest)" FORCE)
 
 # Define a default build type when using a single-mode tool like make/ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,12 @@ endif()
 set(BUILD_BENCHMARK_LOG "${BUILD_BENCHMARK_LOG}"
   CACHE BOOL "Build binary that benchmarks spdlog speed" FORCE)
 
+if(NOT BUILD_TEST_VALUES)
+  set(BUILD_TEST_VALUES OFF)
+endif()
+set(BUILD_TEST_VALUES "${BUILD_TEST_VALUES}"
+  CACHE BOOL "Add the value tests (dependent on gtest)" FORCE)
+
 # Define a default build type when using a single-mode tool like make/ninja
 # We make this default to Release, unless profiling is enabled, in which
 # case do RelWithDebInfo (bcause you need the debug symbols)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The tests in prmon now run in Python3. If your environment does not
 support Python3 properly it is possible to use Python2 for the tests
 by setting `-DPYTHON_TEST=python2`.
 
+To enable pulling and building gtest framework as well as tests dependent on gtest, 
+build with `-DBUILD_GTESTS=ON`.
+
 ### Creating a package with CPack
 
 A cpack based package can be created by invoking

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -9,6 +9,21 @@ target_link_libraries(io-burner PRIVATE Threads::Threads)
 
 add_executable(mem-burner mem-burner.cpp)
 
+if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_TEST_VALUES)
+
+    include(FetchContent)
+    FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+    )
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+    enable_testing()
+
+    include(GoogleTest)
+
+endif()
+
 # Custom targets for handling scripted wrappers for tests
 function(script_install)
     cmake_parse_arguments(SCRIPT_INSTALL "" "SCRIPT;DESTINATION" "" ${ARGN})

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(io-burner PRIVATE Threads::Threads)
 
 add_executable(mem-burner mem-burner.cpp)
 
-if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_TEST_VALUES)
+if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_GTESTS)
 
     include(FetchContent)
     FetchContent_Declare(


### PR DESCRIPTION
`package/tests/CMakeLists.txt` is updated to pull the GoogleTest framework. The minimum cmake version required to pull and run dependent tests is `3.14.0`.

On adding new targets dependent on gtest, please use `gtest_discover_tests(target_name)` to add the tests contained in the target.

A cmake option `BUILD_GTESTS` is added to toggle pulling and building gtest. It is turned off by default.

`build-test.sh` was updated to run CI with `-DBUILD_GTESTS=ON`