### PR TITLE
Fixed netmon initialisation bug #199

### DIFF
--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -87,6 +87,7 @@ class netmon final : public Imonitor, public MessageBase {
   void const get_unit_info(nlohmann::json& unit_json);
   bool const is_valid() { return true; }
 };
-REGISTER_MONITOR(Imonitor, netmon, "Monitor network activity (device level)")
+REGISTER_MONITOR_1ARG(Imonitor, netmon, "Monitor network activity (device level)",
+                std::vector<std::string>)
 
 #endif  // PRMON_NETMON_H

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -19,6 +19,8 @@
 namespace registry {
 
 // Utility macros
+#define REGISTRY_SPACE
+
 #define REGISTRY_CTOR(Base, Derived, params, param_names) \
   [](params) -> Base* { return new Derived(param_names); }
 
@@ -26,6 +28,13 @@ namespace registry {
   static bool _registered_##Derived =                \
       registry::Registry<Base>::register_class(      \
           #Derived, REGISTRY_CTOR(Base, Derived, , ), Description);
+
+#define REGISTER_MONITOR_1ARG(Base, Derived, Description, dtype1)                \
+  static bool _registered_##Derived =                                     \
+      registry::Registry<Base, dtype1>::register_class(                   \
+          #Derived,                                                       \
+          REGISTRY_CTOR(Base, Derived, dtype1 REGISTRY_SPACE arg1, arg1), \
+          Description);
 
 // Empty string to return if there is no description
 static std::string empty_desc = "";

--- a/package/tests/test_values.cpp
+++ b/package/tests/test_values.cpp
@@ -107,7 +107,8 @@ TEST(NetmonTest, NetmonMonitonicityTestFixed) {
   std::vector<pid_t> fake_pids = {{mother_pid}};
 
   std::unique_ptr<Imonitor> monitor(
-      registry::Registry<Imonitor>::create("netmon"));
+      registry::Registry<Imonitor, std::vector<std::string>>::create(
+          "netmon", std::vector<std::string>()));
 
   const int iterationCount = 3;
 


### PR DESCRIPTION
As mentioned in #199, `netmon` is always initialised with the default constructor since the introduction of registry. This is fixed by introducing a new registry macro for registering a subclass with a single argument constructor. 

`netmon` is now initialised with a constructor taking a vector of network devices as input. The network devices passed as arguments in the CLI are passed to the constructor.

Closes #199.