### PR TITLE
Update Python scripts to Python3

### DIFF
--- a/package/scripts/precook_test.py
+++ b/package/scripts/precook_test.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env python3
+"""Generate pre-cooked pseudo /proc output for use with tests"""
+
 import os
 import time
 import random
@@ -201,17 +204,9 @@ def createTestRand(dir_name, iter):
 def main():
     parser = argparse.ArgumentParser(description="Precooked test generator")
 
-    parser.add_argument(
-        "--dir",
-        type=str,
-        help="Name of the directory to be generated",
-    )
+    parser.add_argument("--dir", type=str, help="Name of the directory to be generated")
 
-    parser.add_argument(
-        "--iter",
-        type=int,
-        help="Number of iterations to be generated",
-    )
+    parser.add_argument("--iter", type=int, help="Number of iterations to be generated")
 
     args = parser.parse_args()
 

--- a/package/scripts/prmon_compress_output.py
+++ b/package/scripts/prmon_compress_output.py
@@ -8,7 +8,7 @@ import sys
 try:
     import pandas as pd
 except ImportError:
-    print("{0: <8}:: This script needs pandas.".format("ERROR"))
+    print("ERROR:: This script needs pandas.")
     sys.exit(-1)
 
 

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -209,7 +209,7 @@ def main():
     ylist = args.yvar.split(",")
     for carg in ylist:
         if carg not in list(data):
-            print("ERROR:: Variable {carg} is not available in data")
+            print(f"ERROR:: Variable {carg} is not available in data")
             sys.exit(-1)
 
     # Check the consistency of variables and units
@@ -296,7 +296,7 @@ def main():
     plt.tight_layout()
     fig.savefig(output)
 
-    print("INFO:: Saved output into {output}")
+    print(f"INFO:: Saved output into {output}")
     sys.exit(0)
 
 

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -226,7 +226,7 @@ def main():
         old_yunit = args.yunit
         args.yunit = ALLOWEDUNITS[first_y_variable][0].upper()
         print(
-            "WARNING:: Changing yunit from {old_yunit} to {args.yunit} for consistency"
+            f"WARNING:: Changing yunit from {old_yunit} to {args.yunit} for consistency"
         )
 
     # Check if the user is trying to plot variables with inconsistent units

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -15,11 +15,9 @@ try:
 
     plt.style.use("seaborn-whitegrid")
 except ImportError:
-    print("{0: <8}:: This script needs numpy, pandas and matplotlib.".format("ERROR"))
-    print(
-        "{0: <8}:: Looks like at least one of these modules is missing.".format("ERROR")
-    )
-    print("{0: <8}:: Please install them first and then retry.".format("ERROR"))
+    print("ERROR:: This script needs numpy, pandas and matplotlib.")
+    print("ERROR:: Looks like at least one of these modules is missing.")
+    print("ERROR:: Please install them first and then retry.")
     sys.exit(-1)
 
 # Define the labels/units for beautification
@@ -197,7 +195,7 @@ def main():
 
     # Check the input file exists
     if not os.path.exists(args.input):
-        print("{0: <8}:: Input file {1} does not exists".format("ERROR", args.input))
+        print(f"ERROR:: Input file {args.input} does not exists")
         sys.exit(-1)
 
     # Load the data
@@ -206,16 +204,12 @@ def main():
 
     # Check the variables are in data
     if args.xvar not in list(data):
-        print(
-            "{0: <8}:: Variable {1} is not available in data".format("ERROR", args.xvar)
-        )
+        print(f"ERROR:: Variable {args.xvar} is not available in data")
         sys.exit(-1)
     ylist = args.yvar.split(",")
     for carg in ylist:
         if carg not in list(data):
-            print(
-                "{0: <8}:: Variable {1} is not available in data".format("ERROR", carg)
-            )
+            print("ERROR:: Variable {carg} is not available in data")
             sys.exit(-1)
 
     # Check the consistency of variables and units
@@ -225,35 +219,23 @@ def main():
         old_xunit = args.xunit
         args.xunit = ALLOWEDUNITS[first_x_variable][0].upper()
         print(
-            "{0: <8}:: Changing xunit from {1} to {2} for consistency".format(
-                "WARNING", old_xunit, args.xunit
-            )
+            f"WARNING:: Changing xunit from {old_xunit} to {args.xunit} for consistency"
         )
     first_y_variable = args.yvar.split(",")[0]
     if args.yunit.lower() not in ALLOWEDUNITS[first_y_variable]:
         old_yunit = args.yunit
         args.yunit = ALLOWEDUNITS[first_y_variable][0].upper()
         print(
-            "{0: <8}:: Changing yunit from {1} to {2} for consistency".format(
-                "WARNING", old_yunit, args.yunit
-            )
+            "WARNING:: Changing yunit from {old_yunit} to {args.yunit} for consistency"
         )
 
     # Check if the user is trying to plot variables with inconsistent units
     # If so simply print a message to warn them
     if len({ALLOWEDUNITS[i][0] for i in args.xvar.split(",")}) > 1:
-        print(
-            "{0: <8}:: Elements in xvar have inconsistent units, beware!".format(
-                "WARNING"
-            )
-        )
+        print("WARNING:: Elements in xvar have inconsistent units, beware!")
 
     if len({ALLOWEDUNITS[i][0] for i in args.yvar.split(",")}) > 1:
-        print(
-            "{0: <8}:: Elements in yvar have inconsistent units, beware!".format(
-                "WARNING"
-            )
-        )
+        print("WARNING:: Elements in yvar have inconsistent units, beware!")
 
     # Labels and output information
     xlabel = args.xvar
@@ -314,7 +296,7 @@ def main():
     plt.tight_layout()
     fig.savefig(output)
 
-    print("{0: <8}:: Saved output into {1}".format("INFO", output))
+    print("INFO:: Saved output into {output}")
     sys.exit(0)
 
 

--- a/package/tests/test_count.py
+++ b/package/tests/test_count.py
@@ -56,13 +56,13 @@ def setup_configurable_test(threads=1, procs=1, time=10.0, interval=1, invoke=Fa
                     total_proc,
                     expect_proc,
                     msg="Inconsistent value for number of processes "
-                    "(expected {0}, got {1})".format(expect_proc, total_proc),
+                    f"(expected {expect_proc}, got {total_proc})",
                 )
                 self.assertAlmostEqual(
                     total_thread,
                     expect_thread,
                     msg="Inconsistent value for number of total threads "
-                    "(expected {0}, got {1}".format(expect_thread, total_thread),
+                    f"(expected {expect_thread}, got {total_thread}",
                 )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_cpu.py
+++ b/package/tests/test_cpu.py
@@ -67,15 +67,13 @@ def setup_configurable_test(
                     total_cpu,
                     expect_cpu,
                     "Too high value for CPU time "
-                    "(expected maximum of {0}, got {1})".format(expect_cpu, total_cpu),
+                    f"(expected maximum of {expect_cpu}, got {total_cpu})",
                 )
                 self.assertGreaterEqual(
                     total_cpu,
                     expect_cpu * slack,
                     "Too low value for CPU time "
-                    "(expected minimum of {0}, got {1}".format(
-                        expect_cpu * slack, total_cpu
-                    ),
+                    f"(expected minimum of {expect_cpu*slack}, got {total_cpu}",
                 )
                 # Wall time tests
                 total_wall = prmon_json["Max"]["wtime"]
@@ -83,15 +81,13 @@ def setup_configurable_test(
                     total_wall,
                     time,
                     "Too high value for wall time "
-                    "(expected maximum of {0}, got {1})".format(time, total_wall),
+                    f"(expected maximum of {time}, got {total_wall})",
                 )
                 self.assertGreaterEqual(
                     total_wall,
                     time * slack,
                     "Too low value for wall time "
-                    "(expected minimum of {0}, got {1}".format(
-                        time * slack, total_wall
-                    ),
+                    f"(expected minimum of {time * slack}, got {total_wall}",
                 )
 
                 # Unit test
@@ -103,15 +99,13 @@ def setup_configurable_test(
                         self.assertEqual(
                             len(missing),
                             0,
-                            "Wrong number of unit values for '{0}'".format(group)
-                            + " - missing parameters are {0}".format(missing),
+                            f"Wrong number of unit values for '{group}' - missing parameters are {missing}",
                         )
                         extras = unit_params - value_params
                         self.assertEqual(
                             len(extras),
                             0,
-                            "Wrong number of unit values for '{0}'".format(group)
-                            + " - extra parameters are {0}".format(extras),
+                            f"Wrong number of unit values for '{group}' - extra parameters are {extras}",
                         )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_cpu.py
+++ b/package/tests/test_cpu.py
@@ -99,13 +99,15 @@ def setup_configurable_test(
                         self.assertEqual(
                             len(missing),
                             0,
-                            f"Wrong number of unit values for '{group}' - missing parameters are {missing}",
+                            f"Wrong number of unit values for '{group}' - "
+                            f"missing parameters are {missing}",
                         )
                         extras = unit_params - value_params
                         self.assertEqual(
                             len(extras),
                             0,
-                            f"Wrong number of unit values for '{group}' - extra parameters are {extras}",
+                            f"Wrong number of unit values for '{group}' - "
+                            f"extra parameters are {extras}",
                         )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_exit.py
+++ b/package/tests/test_exit.py
@@ -30,7 +30,7 @@ def setup_configurable_test(exit_code=0):
             self.assertEqual(
                 prmon_rc,
                 exit_code,
-                "Wrong return code from prmon (expected {0}".format(exit_code),
+                f"Wrong return code from prmon (expected {exit_code}",
             )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_io.py
+++ b/package/tests/test_io.py
@@ -52,17 +52,13 @@ def setup_configurable_test(
                     prmon_json["Max"]["wchar"],
                     expected_bytes,
                     "Too low value for IO bytes written "
-                    "(expected minimum of {0}, got {1})".format(
-                        expected_bytes, prmon_json["Max"]["wchar"]
-                    ),
+                    f"(expected minimum of {expected_bytes}, got {prmon_json['Max']['wchar']})",
                 )
                 self.assertGreaterEqual(
                     prmon_json["Max"]["rchar"],
                     expected_bytes,
                     "Too low value for IO bytes read "
-                    "(expected minimum of {0}, got {1})".format(
-                        expected_bytes, prmon_json["Max"]["rchar"]
-                    ),
+                    f"(expected minimum of {expected_bytes}, got {prmon_json['Max']['rchar']})",
                 )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_io.py
+++ b/package/tests/test_io.py
@@ -52,13 +52,15 @@ def setup_configurable_test(
                     prmon_json["Max"]["wchar"],
                     expected_bytes,
                     "Too low value for IO bytes written "
-                    f"(expected minimum of {expected_bytes}, got {prmon_json['Max']['wchar']})",
+                    f"(expected minimum of {expected_bytes}, "
+                    f"got {prmon_json['Max']['wchar']})",
                 )
                 self.assertGreaterEqual(
                     prmon_json["Max"]["rchar"],
                     expected_bytes,
                     "Too low value for IO bytes read "
-                    f"(expected minimum of {expected_bytes}, got {prmon_json['Max']['rchar']})",
+                    f"(expected minimum of {expected_bytes}, "
+                    f"got {prmon_json['Max']['rchar']})",
                 )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_mem.py
+++ b/package/tests/test_mem.py
@@ -27,14 +27,14 @@ def setup_configurable_test(
             self.assertLess(
                 value,
                 max_value,
-                "Too high a value for {0} "
-                "(expected maximum of {1}, got {2})".format(name, max_value, value),
+                f"Too high a value for {name} "
+                f"(expected maximum of {max_value}, got {value})",
             )
             self.assertGreater(
                 value,
                 min_value,
-                "Too low a value for {0} "
-                "(expected maximum of {1}, got {2})".format(name, min_value, value),
+                f"Too low a value for {name} "
+                f"(expected maximum of {min_value}, got {value})",
             )
 
         def test_run_test_with_params(self):

--- a/package/tests/test_net.py
+++ b/package/tests/test_net.py
@@ -69,17 +69,13 @@ def setup_configurable_test(
                     prmon_json["Max"]["rx_bytes"],
                     expected_bytes,
                     "Too low value for rx bytes "
-                    "(expected minimum of {0}, got {1})".format(
-                        expected_bytes, prmon_json["Max"]["rx_bytes"]
-                    ),
+                    f"(expected minimum of {expected_bytes}, got {prmon_json['Max']['rx_bytes']})",
                 )
                 self.assertGreaterEqual(
                     prmon_json["Max"]["tx_bytes"],
                     expected_bytes,
                     "Too low value for tx bytes "
-                    "(expected minimum of {0}, got {1})".format(
-                        expected_bytes, prmon_json["Max"]["tx_bytes"]
-                    ),
+                    "(expected minimum of {expected_bytes}, got {prmon_json['Max']['tx_bytes']})",
                 )
 
     return ConfigurableProcessMonitor

--- a/package/tests/test_net.py
+++ b/package/tests/test_net.py
@@ -69,13 +69,15 @@ def setup_configurable_test(
                     prmon_json["Max"]["rx_bytes"],
                     expected_bytes,
                     "Too low value for rx bytes "
-                    f"(expected minimum of {expected_bytes}, got {prmon_json['Max']['rx_bytes']})",
+                    f"(expected minimum of {expected_bytes}, "
+                    f"got {prmon_json['Max']['rx_bytes']})",
                 )
                 self.assertGreaterEqual(
                     prmon_json["Max"]["tx_bytes"],
                     expected_bytes,
                     "Too low value for tx bytes "
-                    "(expected minimum of {expected_bytes}, got {prmon_json['Max']['tx_bytes']})",
+                    f"(expected minimum of {expected_bytes}, "
+                    f"got {prmon_json['Max']['tx_bytes']})",
                 )
 
     return ConfigurableProcessMonitor


### PR DESCRIPTION
Change from the Python2/3 compatible scripts to ones that
use Python3 features (mainly use of Python f-strings, which are
faster and easier to understand).

Fix the precook_test.py script with a shebang.

Scripts were re-blacked as well.

Closes #202 