### PR TITLE
Add tests against missing fields in prmon txt and json outputs

### DIFF
--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -30,6 +30,7 @@ class Imonitor {
   virtual prmon::monitored_value_map const get_json_total_stats() = 0;
   virtual prmon::monitored_average_map const get_json_average_stats(
       prmon::mon_value elapsed_clock_ticks) = 0;
+  virtual prmon::parameter_list const get_parameter_list() = 0;
 
   virtual void const get_hardware_info(nlohmann::json& hw_json) = 0;
   virtual void const get_unit_info(nlohmann::json& unit_json) = 0;

--- a/package/src/MessageBase.cpp
+++ b/package/src/MessageBase.cpp
@@ -4,6 +4,7 @@
 #include <map>
 
 #include "Imonitor.h"
+#include "prmonutils.h"
 #include "registry.h"
 #include "spdlog/spdlog.h"
 
@@ -32,7 +33,7 @@ void processLevel(std::string s) {
 
     // Check validity of monitor name
     bool valid_monitor = false;
-    auto monitors = registry::Registry<Imonitor>::list_registered();
+    auto monitors = prmon::get_all_registered();
     for (const auto& monitor : monitors) {
       if (monitor == monitor_name) {
         valid_monitor = true;

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -74,7 +74,7 @@ prmon::monitored_value_map const countmon::get_json_total_stats() {
   return count_max_stat_map;
 }
 
-// An the averages
+// And the averages
 prmon::monitored_average_map const countmon::get_json_average_stats(
     unsigned long long elapsed_clock_ticks) {
   prmon::monitored_average_map count_avg_stat_map{};
@@ -83,6 +83,9 @@ prmon::monitored_average_map const countmon::get_json_average_stats(
   }
   return count_avg_stat_map;
 }
+
+// Return the parameter list
+prmon::parameter_list const countmon::get_parameter_list() { return params; }
 
 // Collect related hardware information
 void const countmon::get_hardware_info(nlohmann::json& hw_json) { return; }

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -39,6 +39,7 @@ class countmon final : public Imonitor, public MessageBase {
   prmon::monitored_value_map const get_json_total_stats();
   prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -75,6 +75,9 @@ prmon::monitored_average_map const cpumon::get_json_average_stats(
   return empty_average_stats;
 }
 
+// Return the parameter list
+prmon::parameter_list const cpumon::get_parameter_list() { return params; }
+
 // Collect related hardware information
 void const cpumon::get_hardware_info(nlohmann::json& hw_json) {
   // Define the command and run it

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -38,6 +38,7 @@ class cpumon final : public Imonitor, public MessageBase {
   prmon::monitored_value_map const get_json_total_stats();
   prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -94,6 +94,8 @@ prmon::monitored_average_map const iomon::get_json_average_stats(
   return io_average_stats;
 }
 
+// Return the parameter list
+prmon::parameter_list const iomon::get_parameter_list() { return params; }
 // Collect related hardware information
 void const iomon::get_hardware_info(nlohmann::json& hw_json) { return; }
 

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -39,6 +39,7 @@ class iomon final : public Imonitor, public MessageBase {
   prmon::monitored_value_map const get_json_total_stats();
   prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -90,6 +90,9 @@ prmon::monitored_average_map const memmon::get_json_average_stats(
   return count_avg_stat_map;
 }
 
+// Return the parameter list
+prmon::parameter_list const memmon::get_parameter_list() { return params; }
+
 // Collect related hardware information
 void const memmon::get_hardware_info(nlohmann::json& hw_json) {
   // Read some information from /proc/meminfo

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -42,6 +42,7 @@ class memmon final : public Imonitor, public MessageBase {
   std::map<std::string, unsigned long long> const get_json_total_stats();
   std::map<std::string, double> const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -157,6 +157,9 @@ prmon::monitored_average_map const netmon::get_json_average_stats(
   return json_average_stats;
 }
 
+// Return the parameter list
+prmon::parameter_list const netmon::get_parameter_list() { return params; }
+
 // Collect related hardware information
 void const netmon::get_hardware_info(nlohmann::json& hw_json) { return; }
 

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -81,6 +81,7 @@ class netmon final : public Imonitor, public MessageBase {
   prmon::monitored_value_map const get_json_total_stats();
   prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -191,6 +191,9 @@ bool nvidiamon::test_nvidia_smi() {
   return true;
 }
 
+// Return the parameter list
+prmon::parameter_list const nvidiamon::get_parameter_list() { return params; }
+
 // Collect related hardware information
 void const nvidiamon::get_hardware_info(nlohmann::json& hw_json) {
   // Record the number of GPUs

--- a/package/src/nvidiamon.h
+++ b/package/src/nvidiamon.h
@@ -56,6 +56,7 @@ class nvidiamon final : public Imonitor, public MessageBase {
   prmon::monitored_value_map const get_json_total_stats();
   prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   void const get_hardware_info(nlohmann::json& hw_json);
   void const get_unit_info(nlohmann::json& unit_json);

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -43,12 +43,7 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
   // This is the vector of all monitoring components
   std::unordered_map<std::string, std::unique_ptr<Imonitor>> monitors{};
 
-  auto registered_monitors = registry::Registry<Imonitor>::list_registered();
-  for (const auto& class_name :
-       registry::Registry<Imonitor,
-                          std::vector<std::string>>::list_registered()) {
-    registered_monitors.push_back(class_name);
-  }
+  auto registered_monitors = prmon::get_all_registered();
   for (const auto& class_name : registered_monitors) {
     // Check if the monitor should be enabled
     bool state = true;
@@ -361,7 +356,7 @@ int main(int argc, char* argv[]) {
         << "One of --pid or a child program must be given (but not both)\n"
         << std::endl;
     std::cout << "Monitors available:" << std::endl;
-    auto monitors = registry::Registry<Imonitor>::list_registered();
+    auto monitors = prmon::get_all_registered();
     for (const auto& name : monitors) {
       std::cout << " - " << name << " : "
                 << registry::Registry<Imonitor>::get_description(name)

--- a/package/src/prmonutils.cpp
+++ b/package/src/prmonutils.cpp
@@ -137,7 +137,7 @@ bool valid_monitor_disable(const std::string disable_name) {
     spdlog::error("wallmon monitor cannot be disabled (ignored)");
     return false;
   }
-  auto monitors = registry::Registry<Imonitor>::list_registered();
+  auto monitors = prmon::get_all_registered();
   for (const auto &monitor_name : monitors) {
     if (monitor_name == disable_name) {
       return true;
@@ -172,6 +172,16 @@ void snip_string_and_test(char *env_string, unsigned start, unsigned pos,
   std::string monitor_name(env_string + start, pos - start);
   if (valid_monitor_disable(monitor_name))
     disabled_monitors.push_back(monitor_name);
+}
+
+const std::vector<std::string> get_all_registered() {
+  auto registered_monitors = registry::Registry<Imonitor>::list_registered();
+  for (const auto &monitor :
+       registry::Registry<Imonitor,
+                          std::vector<std::string>>::list_registered()) {
+    registered_monitors.emplace_back(monitor);
+  }
+  return registered_monitors;
 }
 
 }  // namespace prmon

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -36,6 +36,9 @@ void SignalCallbackHandler(int);
 // Child process reaper
 int reap_children();
 
+// Utility function to return list of all registered monitors
+const std::vector<std::string> get_all_registered();
+
 // Precision specifier for average output, to truncate to an integer
 // for anything >avg_precision and round the fraction to
 // essentially 1/avg_precision (thus 1000 = 3 decimal places) for

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -107,6 +107,9 @@ prmon::monitored_average_map const wallmon::get_json_average_stats(
   return empty_average_stats;
 }
 
+// Return the parameter list
+prmon::parameter_list const wallmon::get_parameter_list() { return params; }
+
 // Collect related hardware information
 void const wallmon::get_hardware_info(nlohmann::json& hw_json) { return; }
 

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -45,6 +45,7 @@ class wallmon final : public Imonitor, public MessageBase {
   prmon::monitored_value_map const get_json_total_stats();
   prmon::monitored_average_map const get_json_average_stats(
       unsigned long long elapsed_clock_ticks);
+  prmon::parameter_list const get_parameter_list();
 
   // This is the hardware information getter that runs once
   void const get_hardware_info(nlohmann::json& hw_json);

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_GTESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/iomon.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MessageBase.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/prmonutils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/parameter.cpp
     )
     target_compile_definitions(test_values PRIVATE TESTS_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../scripts/precooked_tests/)
@@ -67,6 +68,40 @@ if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_GTESTS)
                             gtest_main
     )
     gtest_discover_tests(test_values)
+
+    add_executable(test_fields test_fields.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/countmon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/cpumon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/memmon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/netmon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/nvidiamon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/iomon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/MessageBase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/prmonutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/utils.cpp
+    )
+    target_compile_definitions(test_fields PRIVATE PRMON_SOURCE_DIR=${CMAKE_BINARY_DIR})
+
+    target_include_directories(test_fields PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    )
+    if(TARGET nlohmann_json::nlohmann_json)
+    target_link_libraries(test_fields
+                            PRIVATE
+                            nlohmann_json::nlohmann_json
+    )
+    endif(TARGET nlohmann_json::nlohmann_json)
+    target_link_libraries(test_fields
+                            PRIVATE
+                            Threads::Threads
+                            gtest_main
+    )
+    add_test(NAME testFieldsAll COMMAND test_fields)
+    add_test(NAME testFieldsSomeDisabled COMMAND test_fields --disable netmon --disable cpumon)
 
 endif()
 

--- a/package/tests/test_fields.cpp
+++ b/package/tests/test_fields.cpp
@@ -1,0 +1,209 @@
+#include <getopt.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+
+#include "../../prmonVersion.h"
+#include "../src/Imonitor.h"
+#include "../src/countmon.h"
+#include "../src/cpumon.h"
+#include "../src/iomon.h"
+#include "../src/memmon.h"
+#include "../src/netmon.h"
+#include "../src/nvidiamon.h"
+#include "../src/prmonutils.h"
+#include "../src/registry.h"
+#include "gtest/gtest.h"
+
+const int mother_pid = 1729;
+
+#define TO_STRING2(X) #X
+#define TO_STRING(X) TO_STRING2(X)
+
+const std::string base_path = TO_STRING(PRMON_SOURCE_DIR);
+const std::string prmon_path = base_path + "/package/prmon";
+
+bool prmon::sigusr1 = false;
+
+int run_prmon(const std::vector<std::string>& disabled_monitors) {
+  pid_t parent_pid = getpid();
+  pid_t pid = fork();
+  if (pid < 0) {
+    return 1;
+  }
+  if (pid > 0) {
+    sleep(3);
+  } else {
+    std::vector<std::string> arg_list = {prmon_path, "--pid",
+                                         std::to_string(parent_pid)};
+    for (const auto& monitor : disabled_monitors) {
+      arg_list.push_back("--disable");
+      arg_list.push_back(monitor);
+    }
+    int exec_argc = arg_list.size() + 1;
+    char** exec_argv = (char**)malloc(exec_argc * sizeof(char*));
+
+    for (int i = 0; i < exec_argc - 1; ++i) {
+      exec_argv[i] = (char*)arg_list[i].c_str();
+    }
+    exec_argv[exec_argc - 1] = NULL;
+    execvp(exec_argv[0], exec_argv);
+  }
+  kill(pid, SIGTERM);
+  return 0;
+}
+
+std::vector<std::string> get_enabled_monitors(
+    const std::vector<std::string>& disabled_monitors) {
+  auto registered_monitors = prmon::get_all_registered();
+  std::vector<std::string> enabled_monitors;
+  for (const auto& monitor : registered_monitors) {
+    bool enabled = true;
+    for (const auto& disabled_monitor : disabled_monitors) {
+      if (monitor == disabled_monitor) {
+        enabled = false;
+        break;
+      }
+    }
+    if (enabled) enabled_monitors.push_back(monitor);
+  }
+  return enabled_monitors;
+}
+
+std::unordered_map<std::string, prmon::parameter_list> get_parameters(
+    const std::vector<std::string>& disabled_monitors) {
+  std::unordered_map<std::string, prmon::parameter_list> monitor_params{};
+  std::vector<std::string> netdevs;
+  auto registered_monitors = prmon::get_all_registered();
+  for (const auto& class_name : registered_monitors) {
+    // Check if the monitor should be enabled
+    bool state = true;
+    for (const auto& disabled : disabled_monitors) {
+      if (class_name == disabled) state = false;
+    }
+    if (state) {
+      std::unique_ptr<Imonitor> new_monitor_p;
+      if (class_name == "netmon") {
+        new_monitor_p = std::unique_ptr<Imonitor>(
+            registry::Registry<Imonitor, std::vector<std::string>>::create(
+                class_name, netdevs));
+      } else {
+        new_monitor_p = std::unique_ptr<Imonitor>(
+            registry::Registry<Imonitor>::create(class_name));
+      }
+      if (new_monitor_p) {
+        if (new_monitor_p->is_valid()) {
+          monitor_params[class_name] = new_monitor_p->get_parameter_list();
+        }
+      } else {
+        spdlog::error("Registration of monitor " + class_name + " FAILED");
+      }
+    }
+  }
+  return monitor_params;
+}
+
+std::unordered_map<std::string, std::vector<std::string>> get_json_params() {
+  nlohmann::json json_file;
+  std::ifstream f("prmon.json_snapshot");
+  f >> json_file;
+  std::unordered_map<std::string, std::vector<std::string>> params;
+  for (const auto& elem : json_file.items()) {
+    if (elem.key() == "Avg" || elem.key() == "Max") {
+      for (const auto& field : elem.value().items()) {
+        params[elem.key()].push_back(field.key());
+      }
+    }
+  }
+  return params;
+}
+
+std::vector<std::string> get_prmon_txt_params() {
+  std::ifstream f("prmon.txt");
+  std::string line, field;
+  std::getline(f, line);
+  std::stringstream field_stream(line);
+  std::vector<std::string> field_list;
+  while (field_stream >> field) field_list.emplace_back(field);
+  return field_list;
+}
+
+std::unordered_map<std::string, prmon::parameter_list> monitor_params;
+
+TEST(JsonTest, JsonFieldsTest) {
+  const auto& json_params = get_json_params();
+  for (const auto& monitor_param : monitor_params) {
+    for (const auto& param : monitor_param.second) {
+      bool avg_found = false, max_found = false;
+      for (const auto& json_param : json_params.at("Avg")) {
+        if (param.get_name() == json_param) {
+          avg_found = true;
+          break;
+        }
+      }
+      for (const auto& json_param : json_params.at("Max")) {
+        if (param.get_name() == json_param) {
+          max_found = true;
+          break;
+        }
+      }
+      if (param.get_name().size() < 4 ||
+          param.get_name().substr((int)param.get_name().size() - 4, 4) !=
+              "time") {
+        ASSERT_EQ(avg_found, true)
+            << param.get_name() << " from " << monitor_param.first
+            << " not found in json averages\n";
+      }
+      ASSERT_EQ(max_found, true)
+          << param.get_name() << " from " << monitor_param.first
+          << " not found in json maximums\n";
+    }
+  }
+}
+
+TEST(TxtTest, TxtFieldsTest) {
+  const auto& txt_params = get_prmon_txt_params();
+  for (const auto& monitor_param : monitor_params) {
+    for (const auto& param : monitor_param.second) {
+      bool found = false;
+      for (const auto& txt_param : txt_params) {
+        if (param.get_name() == txt_param) {
+          found = true;
+          break;
+        }
+      }
+      ASSERT_EQ(found, true)
+          << param.get_name() << " from " << monitor_param.first
+          << " not found in txt fields\n";
+    }
+  }
+}
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  static struct option long_options[] = {
+      {"disable", required_argument, NULL, 'd'}, {0, 0, 0, 0}};
+  std::vector<std::string> disabled_monitors;
+  int c;
+  while ((c = getopt_long(argc, argv, "-d:", long_options, NULL)) != -1) {
+    switch (c) {
+      case 'd':
+        if (prmon::valid_monitor_disable(optarg))
+          disabled_monitors.push_back(optarg);
+        break;
+      default:
+        std::cout << "Invalid option!" << std::endl;
+        return 1;
+    }
+  }
+  run_prmon(disabled_monitors);
+  monitor_params = get_parameters(disabled_monitors);
+  return RUN_ALL_TESTS();
+}

--- a/package/tests/test_values.cpp
+++ b/package/tests/test_values.cpp
@@ -21,6 +21,8 @@ const int mother_pid = 1729;
 
 const std::string base_path = TO_STRING(TESTS_SOURCE_DIR);
 
+bool prmon::sigusr1 = false;
+
 TEST(IomonTest, IomonMonitonicityTestFixed) {
   std::string cur_path = base_path + "drop";
   std::vector<pid_t> fake_pids = {{mother_pid}};


### PR DESCRIPTION
`test_fields.cpp` is added which parses the `prmon.txt` and `prmon.json_snapshot` files and checks that the expected fields are present. It takes options `--disable mon` similar to prmon which allows testing of fields when certain monitors are disabled.

A function is added to the monitors which returns the parameter list for the monitor. This is used to get the parameters for each monitor.