### PR TITLE
Fix wallclock units

### DIFF
--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -157,7 +157,7 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
           }
         }
         for (const auto& monitor : monitors) {
-          auto wallclock_time = wallclock_monitor_p->get_wallclock_clock_t();
+          auto wallclock_time = wallclock_monitor_p->get_wallclock_t();
           for (const auto& stat :
                monitor.second->get_json_average_stats(wallclock_time)) {
             // We will limit the decimal place accuracy here as it doesn't
@@ -221,9 +221,7 @@ int ProcessMonitor(const pid_t mpid, const std::string filename,
   file.close();
 
   // Check that we ran for a reasonable number of iterations
-  if (wallclock_monitor_p->get_wallclock_clock_t() /
-          (interval * sysconf(_SC_CLK_TCK)) <
-      1) {
+  if (wallclock_monitor_p->get_wallclock_t() < prmon::mon_value(interval)) {
     spdlog::warn(
         "Wallclock time of monitored process was less than the monitoring "
         "interval, so average statistics will be unreliable");

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -79,7 +79,7 @@ void wallmon::update_stats(const std::vector<pid_t>& pids,
   walltime_stats.at("wtime").set_value(uptime_sec);
 }
 
-prmon::mon_value const wallmon::get_wallclock_clock_t() {
+prmon::mon_value const wallmon::get_wallclock_t() {
   // Just ensure we never return a zero
   return (walltime_stats.at("wtime").get_value()
               ? walltime_stats.at("wtime").get_value()

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -50,8 +50,8 @@ class wallmon final : public Imonitor, public MessageBase {
   void const get_hardware_info(nlohmann::json& hw_json);
   void const get_unit_info(nlohmann::json& unit_json);
 
-  // Class specific method to retrieve wallclock time in clock ticks
-  unsigned long long const get_wallclock_clock_t();
+  // Class specific method to retrieve wallclock time (in seconds)
+  unsigned long long const get_wallclock_t();
 
   bool const is_valid() { return true; }
 };


### PR DESCRIPTION
After the transition to the parameter value class
the wallclock monitor now stores values internally
in seconds, not in clock ticks. This lead to a wrong
comparison for the short wallclock warning.

In addition to fixing the test, the method is renamed
to avoid confusion.