### PR TITLE
Start installing prmon_compress_output.py by default

### DIFF
--- a/package/scripts/CMakeLists.txt
+++ b/package/scripts/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Install the scripts under bin in the install area
-install(PROGRAMS prmon_plot.py DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(PROGRAMS prmon_plot.py prmon_compress_output.py DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
With this PR we'll start installing the `prmon_compress_output.py` script.