### PR TITLE
Fix the clang compilation issue reported in #210

### DIFF
--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -30,7 +30,7 @@ std::pair<int, unsigned long long> wallmon::get_mother_starttime(
   std::vector<std::string> stat_entries{};
   stat_entries.reserve(52);
   std::string tmp_str{};
-  unsigned long long start_time_clock_t;
+  unsigned long long start_time_clock;
 
   std::stringstream stat_fname{};
   stat_fname << "/proc/" << mother_pid << "/stat" << std::ends;
@@ -40,7 +40,7 @@ std::pair<int, unsigned long long> wallmon::get_mother_starttime(
     if (proc_stat) stat_entries.push_back(tmp_str);
   }
   if (stat_entries.size() > prmon::uptime_pos) {
-    start_time_clock_t = std::stol(stat_entries[prmon::uptime_pos]);
+    start_time_clock = std::stol(stat_entries[prmon::uptime_pos]);
   } else {
     // Some error happened!
     std::stringstream strm;
@@ -51,7 +51,7 @@ std::pair<int, unsigned long long> wallmon::get_mother_starttime(
     warning(strm.str());
     return std::pair<int, unsigned long long>{1, 0L};
   }
-  return std::pair<int, unsigned long long>{0, start_time_clock_t};
+  return std::pair<int, unsigned long long>{0, start_time_clock};
 }
 
 void wallmon::update_stats(const std::vector<pid_t>& pids,

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -27,8 +27,6 @@ class wallmon final : public Imonitor, public MessageBase {
   // "map" of monitored parameters (even if there's only one!)
   prmon::monitored_list walltime_stats;
 
-  unsigned long long start_time_clock_t, current_clock_t;
-
   // Only need to get the mother start time once, so use
   // a bool to say when it's done
   bool got_mother_starttime;


### PR DESCRIPTION
This should fix the reported error. However, I also noticed that the memory unit tests are failing in the clang builds. That needs to be investigated (might be related to different optimizations). A good reminder to add a clang based CI workflow to catch similar issues in the future (as discussed in #201). 

Closes #210 