### PR TITLE
Clang fixes

### DIFF
--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -27,8 +27,6 @@ class wallmon final : public Imonitor, public MessageBase {
   // "map" of monitored parameters (even if there's only one!)
   prmon::monitored_list walltime_stats;
 
-  unsigned long long start_time_clock_t, current_clock_t;
-
   // Only need to get the mother start time once, so use
   // a bool to say when it's done
   bool got_mother_starttime;

--- a/package/tests/CMakeLists.txt
+++ b/package/tests/CMakeLists.txt
@@ -8,6 +8,11 @@ add_executable(io-burner io-burner.cpp)
 target_link_libraries(io-burner PRIVATE Threads::Threads)
 
 add_executable(mem-burner mem-burner.cpp)
+# Clang has some builtin optimisations around malloc() that
+# mess up this test, so disable them here
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  set_target_properties(mem-burner PROPERTIES COMPILE_FLAGS "-fno-builtin")
+endif()
 
 if (${CMAKE_VERSION} VERSION_GREATER "3.14.0" AND BUILD_GTESTS)
 

--- a/package/tests/test_fields.cpp
+++ b/package/tests/test_fields.cpp
@@ -23,8 +23,6 @@
 #include "../src/registry.h"
 #include "gtest/gtest.h"
 
-const int mother_pid = 1729;
-
 #define TO_STRING2(X) #X
 #define TO_STRING(X) TO_STRING2(X)
 

--- a/package/tests/test_values.cpp
+++ b/package/tests/test_values.cpp
@@ -14,7 +14,7 @@
 #include "../src/registry.h"
 #include "gtest/gtest.h"
 
-const int mother_pid = 1729;
+const std::vector<pid_t> mother_pid {1729};
 
 #define TO_STRING2(X) #X
 #define TO_STRING(X) TO_STRING2(X)
@@ -25,7 +25,7 @@ bool prmon::sigusr1 = false;
 
 TEST(IomonTest, IomonMonitonicityTestFixed) {
   std::string cur_path = base_path + "drop";
-  std::vector<pid_t> fake_pids = {{mother_pid}};
+  std::vector<pid_t> fake_pids = mother_pid;
 
   std::unique_ptr<Imonitor> monitor(
       registry::Registry<Imonitor>::create("iomon"));
@@ -52,7 +52,7 @@ TEST(IomonTest, IomonMonitonicityTestFixed) {
 
 TEST(CpumonTest, CpumonMonitonicityTestFixed) {
   std::string cur_path = base_path + "drop";
-  std::vector<pid_t> fake_pids = {{mother_pid}};
+  std::vector<pid_t> fake_pids = mother_pid;
 
   std::unique_ptr<Imonitor> monitor(
       registry::Registry<Imonitor>::create("cpumon"));
@@ -79,7 +79,7 @@ TEST(CpumonTest, CpumonMonitonicityTestFixed) {
 
 TEST(MemmonTest, MemmonValueTestFixed) {
   std::string cur_path = base_path + "drop";
-  std::vector<pid_t> fake_pids = {{mother_pid}};
+  std::vector<pid_t> fake_pids = mother_pid;
 
   std::unique_ptr<Imonitor> monitor(
       registry::Registry<Imonitor>::create("memmon"));
@@ -106,7 +106,7 @@ TEST(MemmonTest, MemmonValueTestFixed) {
 
 TEST(NetmonTest, NetmonMonitonicityTestFixed) {
   std::string cur_path = base_path + "drop";
-  std::vector<pid_t> fake_pids = {{mother_pid}};
+  std::vector<pid_t> fake_pids = mother_pid;
 
   std::unique_ptr<Imonitor> monitor(
       registry::Registry<Imonitor, std::vector<std::string>>::create(
@@ -134,7 +134,7 @@ TEST(NetmonTest, NetmonMonitonicityTestFixed) {
 
 TEST(NvidiamonTest, NvidiamonValueTestFixed) {
   std::string cur_path = base_path + "drop";
-  std::vector<pid_t> fake_pids = {{mother_pid}};
+  std::vector<pid_t> fake_pids = mother_pid;
 
   std::unique_ptr<Imonitor> monitor(
       registry::Registry<Imonitor>::create("nvidiamon"));

--- a/package/tests/test_values.cpp
+++ b/package/tests/test_values.cpp
@@ -14,7 +14,7 @@
 #include "../src/registry.h"
 #include "gtest/gtest.h"
 
-const std::vector<pid_t> mother_pid {1729};
+const std::vector<pid_t> mother_pid{1729};
 
 #define TO_STRING2(X) #X
 #define TO_STRING(X) TO_STRING2(X)


### PR DESCRIPTION
Fix a few issues found with clang compilation:

- unused variables
- extra braces in uniform initalisers

Also prevent clang for optimising `malloc()` when running the memory usage test, as this messes with the VMEM figures and causes the tests to fail.

With this patch the clang build and all tests (inc. Gtests) compile and run successfully.

Closes #210 