### PR TITLE
Clang CI option

### DIFF
--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -9,14 +9,14 @@
 cd /tmp
 echo "Starting container run for platform $PLATFORM, compiler suite $COMPILER"
 if [ -z "$CXX" ]; then
-	if [ $COMPILER == "clang" ]; then
+	if [ "$COMPILER" == "clang" ]; then
 		CXX=$(type -p clang++)
 	fi
 	# gcc suite is the fall through
     CXX=$(type -p g++)
 fi
 if [ -z "$CC" ]; then
-	if [ $COMPILER == "clang" ]; then
+	if [ "$COMPILER" == "clang" ]; then
 		CXX=$(type -p clang)
 	fi
 	CC=$(type -p gcc)

--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -7,7 +7,7 @@
 # container; CMAKE_EXTRA can be used to pass special options
 # to cmake for particular platforms
 cd /tmp
-echo "Starting container run for platform $PLATFORM, compiler suite $COMPILER"
+echo "Starting build and test for platform $PLATFORM, compiler suite $COMPILER"
 if [ -z "$CXX" ]; then
 	if [ "$COMPILER" == "clang" ]; then
 		CXX=$(type -p clang++)
@@ -17,7 +17,7 @@ if [ -z "$CXX" ]; then
 fi
 if [ -z "$CC" ]; then
 	if [ "$COMPILER" == "clang" ]; then
-		CXX=$(type -p clang)
+		CC=$(type -p clang)
 	fi
 	CC=$(type -p gcc)
 fi

--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -1,16 +1,24 @@
 #! /usr/bin/env bash
 #
-# Wrapper script to build prmon on travis and run all tests
+# Wrapper script to build prmon and run all tests
 #
 # Note that CXX, CC and CMAKE can all be customised so that
 # they can be matched to the development environment in each
 # container; CMAKE_EXTRA can be used to pass special options
 # to cmake for particular platforms
 cd /tmp
+echo "Starting container run for platform $PLATFORM, compiler suite $COMPILER"
 if [ -z "$CXX" ]; then
+	if [ $COMPILER == "clang" ]; then
+		CXX=$(type -p clang++)
+	fi
+	# gcc suite is the fall through
     CXX=$(type -p g++)
 fi
 if [ -z "$CC" ]; then
+	if [ $COMPILER == "clang" ]; then
+		CXX=$(type -p clang)
+	fi
 	CC=$(type -p gcc)
 fi
 if [ -z "$CMAKE" ]; then

--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -15,7 +15,10 @@ if [ -z "$CXX" ]; then
 		# gcc suite is the fall through
     	CXX=$(type -p g++)
 	fi
+else
+	echo "CXX was set externally to $CXX"
 fi
+
 if [ -z "$CC" ]; then
 	if [ "$COMPILER" == "clang" ]; then
 		CC=$(type -p clang)
@@ -23,7 +26,10 @@ if [ -z "$CC" ]; then
 		# gcc suite is the fall through
 		CC=$(type -p gcc)
 	fi
+else
+	echo "CC was set externally to $CC"
 fi
+
 if [ -z "$CMAKE" ]; then
 	CMAKE=$(type -p cmake)
 fi

--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -9,29 +9,29 @@
 cd /tmp
 echo "Starting build and test for platform $PLATFORM, compiler suite $COMPILER"
 if [ -z "$CXX" ]; then
-	if [ "$COMPILER" == "clang" ]; then
-		CXX=$(type -p clang++)
-	else
-		# gcc suite is the fall through
-    	CXX=$(type -p g++)
-	fi
+    if [ "$COMPILER" == "clang" ]; then
+        CXX=$(type -p clang++)
+    else
+        # gcc suite is the fall through
+        CXX=$(type -p g++)
+    fi
 else
-	echo "CXX was set externally to $CXX"
+    echo "CXX was set externally to $CXX"
 fi
 
 if [ -z "$CC" ]; then
-	if [ "$COMPILER" == "clang" ]; then
-		CC=$(type -p clang)
-	else
-		# gcc suite is the fall through
-		CC=$(type -p gcc)
-	fi
+    if [ "$COMPILER" == "clang" ]; then
+        CC=$(type -p clang)
+    else
+        # gcc suite is the fall through
+        CC=$(type -p gcc)
+    fi
 else
-	echo "CC was set externally to $CC"
+    echo "CC was set externally to $CC"
 fi
 
 if [ -z "$CMAKE" ]; then
-	CMAKE=$(type -p cmake)
+    CMAKE=$(type -p cmake)
 fi
 
 # For debugging, handy to print what we're doing

--- a/.github/scripts/build-test.sh
+++ b/.github/scripts/build-test.sh
@@ -11,15 +11,18 @@ echo "Starting build and test for platform $PLATFORM, compiler suite $COMPILER"
 if [ -z "$CXX" ]; then
 	if [ "$COMPILER" == "clang" ]; then
 		CXX=$(type -p clang++)
+	else
+		# gcc suite is the fall through
+    	CXX=$(type -p g++)
 	fi
-	# gcc suite is the fall through
-    CXX=$(type -p g++)
 fi
 if [ -z "$CC" ]; then
 	if [ "$COMPILER" == "clang" ]; then
 		CC=$(type -p clang)
+	else
+		# gcc suite is the fall through
+		CC=$(type -p gcc)
 	fi
-	CC=$(type -p gcc)
 fi
 if [ -z "$CMAKE" ]; then
 	CMAKE=$(type -p cmake)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
     strategy:
       matrix:
         platform: [ c7-dev, c8-dev, u20-dev ]
+        compiler: [ gcc ]
+        include:
+          # On C8 we also test clang
+          - platform: c8-dev
+            compiler: clang
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -34,6 +39,7 @@ jobs:
         echo "DIMAGE=hepsoftwarefoundation/$PLATFORM" >> $GITHUB_ENV
       env:
         PLATFORM: ${{ matrix.platform }}
+        COMPILER: ${{ matrix.compiler }}
 
     # Pulls the associated Docker image
     - name: Docker pull
@@ -42,15 +48,16 @@ jobs:
     # Builds the code and runs the test
     - name: Build and test
       run: |
+        echo "Running on $PLATFORM, compiler $COMPILER"
         if [[ "$DIMAGE" == *c7-dev ]];
         then
           docker run -e CMAKE=cmake3 -e CMAKE_EXTRA=$CMAKE_EXTRA -v $(pwd):/mnt $DIMAGE scl enable devtoolset-8 /mnt/.github/scripts/build-test.sh;
         elif [[ "$DIMAGE" == *c8-dev ]];
         then
-          docker run -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
+          docker run -e PLATFORM -e COMPILER= -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
         elif [[ "$DIMAGE" == *u20-dev ]];
         then
-          docker run -e CXX=g++-9 -e CC=gcc-9 -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
+          docker run -e PLATFORM -e CXX=g++-9 -e CC=gcc-9 -e COMPILER -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
         else
           echo "Unkown Docker Image: $DIMAGE"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,13 @@ jobs:
         echo "Starting run for $PLATFORM, compiler suite $COMPILER"
         if [[ "$DIMAGE" == *c7-dev ]];
         then
-          docker run -e CMAKE=cmake3 -e CMAKE_EXTRA=$CMAKE_EXTRA -v $(pwd):/mnt $DIMAGE scl enable devtoolset-8 /mnt/.github/scripts/build-test.sh;
+          docker run -e PLATFORM -e COMPILER -e CMAKE=cmake3 -e CMAKE_EXTRA=$CMAKE_EXTRA -v $(pwd):/mnt $DIMAGE scl enable devtoolset-8 /mnt/.github/scripts/build-test.sh;
         elif [[ "$DIMAGE" == *c8-dev ]];
         then
           docker run -e PLATFORM -e COMPILER -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
         elif [[ "$DIMAGE" == *u20-dev ]];
         then
-          docker run -e PLATFORM -e CXX=g++-9 -e CC=gcc-9 -e COMPILER -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
+          docker run -e PLATFORM -e COMPILER -e CXX=g++-9 -e CC=gcc-9 -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
         else
           echo "Unkown Docker Image: $DIMAGE"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
     - name: Setup environment variables
       run: |
         echo "DIMAGE=hepsoftwarefoundation/$PLATFORM" >> $GITHUB_ENV
+        echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
+        echo "COMPILER=$COMPILER" >> $GITHUB_ENV
       env:
         PLATFORM: ${{ matrix.platform }}
         COMPILER: ${{ matrix.compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     # Builds the code and runs the test
     - name: Build and test
       run: |
-        echo "Running on $PLATFORM, compiler $COMPILER"
+        echo "Starting run for $PLATFORM, compiler suite $COMPILER"
         if [[ "$DIMAGE" == *c7-dev ]];
         then
           docker run -e CMAKE=cmake3 -e CMAKE_EXTRA=$CMAKE_EXTRA -v $(pwd):/mnt $DIMAGE scl enable devtoolset-8 /mnt/.github/scripts/build-test.sh;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           docker run -e CMAKE=cmake3 -e CMAKE_EXTRA=$CMAKE_EXTRA -v $(pwd):/mnt $DIMAGE scl enable devtoolset-8 /mnt/.github/scripts/build-test.sh;
         elif [[ "$DIMAGE" == *c8-dev ]];
         then
-          docker run -e PLATFORM -e COMPILER= -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
+          docker run -e PLATFORM -e COMPILER -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;
         elif [[ "$DIMAGE" == *u20-dev ]];
         then
           docker run -e PLATFORM -e CXX=g++-9 -e CC=gcc-9 -e COMPILER -v $(pwd):/mnt $DIMAGE /mnt/.github/scripts/build-test.sh;


### PR DESCRIPTION
For the c8-dev platform activate also a build with clang

We add an additional martix variable (compiler) that propages through to the environment, that triggers settng the C++ compiler to clang++. It would be then easy to add this compiler (or any other) for as many platforms as we think we need.

Closes #201 