### PR TITLE
Add source release action

### DIFF
--- a/.github/workflows/build-source-release.yml
+++ b/.github/workflows/build-source-release.yml
@@ -20,12 +20,12 @@ jobs:
       id: archive
       run: |
         VERSION=${{ github.event.release.tag_name }}
-        PKGNAME="prmon-source-$VERSION"
-        mkdir -p /tmp/$PKGNAME
-        mv * /tmp/$PKGNAME
-        mv /tmp/$PKGNAME .
-        TARBALL=$PKGNAME.tar.xz
-        tar cJf $TARBALL $PKGNAME
+        SRCNAME="prmon-$VERSION"
+        mkdir -p /tmp/$SRCNAME
+        mv * /tmp/$SRCNAME
+        mv /tmp/$SRCNAME .
+        TARBALL=$VERSION.tar.xz
+        tar cJf $TARBALL $SRCNAME
         echo "::set-output name=tarball::$TARBALL"
     - name: upload tarball
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-source-release.yml
+++ b/.github/workflows/build-source-release.yml
@@ -1,0 +1,38 @@
+name: Build Source Release
+
+# Trigger whenever a release is created
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: archive
+      id: archive
+      run: |
+        VERSION=${{ github.event.release.tag_name }}
+        PKGNAME="prmon-source-$VERSION"
+        mkdir -p /tmp/$PKGNAME
+        mv * /tmp/$PKGNAME
+        mv /tmp/$PKGNAME .
+        TARBALL=$PKGNAME.tar.xz
+        tar cJf $TARBALL $PKGNAME
+        echo "::set-output name=tarball::$TARBALL"
+    - name: upload tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.archive.outputs.tarball }}
+        asset_name: ${{ steps.archive.outputs.tarball }}
+        asset_content_type: application/gzip


### PR DESCRIPTION
As the GitHub source archives do not contain any
submodules they are not very useful for people
wishing to build a released
version of prmon. This action should build a source release
archive with resursion switched on at checkout, so that
spdlog will be included correctly.

Closes #209 