### PR TITLE
Support both external and internal dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
-[submodule "submodules/spdlog"]
-	path = submodules/spdlog
-	url = https://github.com/gabime/spdlog.git
 [submodule "submodules/nlohmann_json"]
+	shallow = true
 	path = submodules/nlohmann_json
 	url = https://github.com/nlohmann/json.git
+[submodule "submodules/spdlog"]
+	shallow = true
+	path = submodules/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodules/spdlog"]
 	path = submodules/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "submodules/nlohmann_json"]
+	path = submodules/nlohmann_json
+	url = https://github.com/nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,11 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
               ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE
               DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
+#--- project dependencies ------------------------------------------------------
+include(cmake/prmonDependencies.cmake)
+
 #--- project specific subdirectories -------------------------------------------
+
 add_subdirectory(package)
 
 #--- include directories -------------------------------------------

--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ As prmon has dependencies on submodules, clone the project as
 ### Building the project
 
 Building prmon requires a C++ compiler that fully supports C++11,
-CMake version 3.3 or
-higher and the [Niels Lohmann JSON libraries](https://github.com/nlohmann/json).
+and CMake version 3.3 or higher.  It also has dependencies on:
 
-Building is usually as simple as
+  - [Niels Lohmann JSON libraries](https://github.com/nlohmann/json)
+    - `nlohmann-json-dev` in Ubuntu 18, `nlohmann-json3-dev` in Ubuntu 20
+  - [spdlog: Fast C++ logging library](https://github.com/gabime/spdlog)
+    - `libspdlog-dev` in Ubuntu
+
+and can use either external system-supplied versions or internal copies
+provided by submodules.
+
+Building is usually as simple as:
 
     mkdir build
     cd build
@@ -47,10 +54,26 @@ Building is usually as simple as
     make -j<number of cores on your machine>
     make install
 
-If your installation of JSON is in a non-standard location then
-setting `nlohmann_json_DIR` may be required as a hint to CMake.
-(e.g. this is necessary on Ubuntu18 when using the standard `nlohmann-json-dev`
-package: `-Dnlohmann_json_DIR=/usr/lib/cmake`.)
+Unless otherwise specified, the default behavior for dependencies is to first
+try to find an external version and fall back to the internal submodule copy
+if not found.  To explicitly force the use of either add any of the following
+configure options:
+  - `-DUSE_EXTERNAL_NLOHMANN_JSON={TRUE,FALSE,`**`AUTO`**`}`
+    - `ON`, `TRUE`: Force an external version and fail if not found.
+    - `OFF`, `FALSE`: Require the internal copy be used.
+    - **`AUTO`**: Search for an external version and fall back to the
+       internal copy if not found.
+  - `-Dnlohmann_json_DIR=/path/to/config`
+    - The path to the directory containing `nlohmann_jsonConfig.cmake`.
+      Necessary if nlohmann_json is not installed into CMake's search path.
+  - `-DUSE_EXTERNAL_SPDLOG={TRUE,FALSE,`**`AUTO`**`}`
+    - `ON`, `TRUE`: Force an external version and fail if not found.
+    - `OFF`, `FALSE`: Require the internal copy be used.
+    - **`AUTO`**: Search for an external version and fall back to the
+       internal copy if not found.
+  - `-Dspdlog_DIR=/path/to/config`
+    - The path to the directory containing `spdlogConfig.cmake`.
+      Necessary if spdlog is not installed into CMake's search path.
 
 The option `-DCMAKE_BUILD_TYPE` can switch between all of the standard
 build types. The default is `Release`; use `RelWithDebInfo` if you want

--- a/cmake/prmonDependencies.cmake
+++ b/cmake/prmonDependencies.cmake
@@ -1,37 +1,47 @@
+# A helper function to add dependencies supporting both internal and external
+# versions.  This adds a dependency with the following arguments:
+#   _cmake_name - The name of the dependency's CMake pacakge used in
+#                 find_package(${_cmake_name})
+#   _opt_name   - The configure option to create as USE_EXTERNAL_${_opt_name}
+#   _sub_name   - The name of the submodule the intal copy resides in at
+#                 submodules/${_sub_name}
+#
+# Note: The reason for all the manual logging is only some package configs
+#       give useful output so we're just calling find_package(... QUIET)
+#       and doing the logging ourselves.
+macro(_prmon_add_internal_external_dependency _cmake_name _opt_name _sub_name)
+  set(USE_EXTERNAL_${_opt_name} AUTO CACHE STRING "Use an external ${_cmake_name}")
+  set_property(CACHE USE_EXTERNAL_${_opt_name} PROPERTY
+    STRINGS "ON;TRUE;AUTO;OFF;FALSE")
+  mark_as_advanced(USE_EXTERNAL_${_opt_name})
+  if(USE_EXTERNAL_${_opt_name} STREQUAL AUTO)
+    find_package(${_cmake_name} CONFIG QUIET)
+  elseif(USE_EXTERNAL_${_opt_name})
+    find_package(${_cmake_name} CONFIG REQUIRED QUIET)
+  endif()
+  if(${_cmake_name}_FOUND)
+    message(STATUS "Found ${_cmake_name}: ${${_cmake_name}_CONFIG} (found version \"${${_cmake_name}_VERSION}\")")
+  else() # USE_EXTERNAL_${_opt_name} = OFF or AUTO and failed to find above
+    if(USE_EXTERNAL_${_opt_name} STREQUAL AUTO)
+      message(STATUS "External ${_cmake_name} not found, using internal submodule")
+    else()
+      message(STATUS "Forcing internal submodule for ${_cmake_name}")
+    endif()
+    if (NOT EXISTS ${PROJECT_SOURCE_DIR}/submodules/${_sub_name}/CMakeLists.txt)
+      message(FATAL_ERROR "${_cmake_name} submodule is not available")
+    endif()
+    add_subdirectory(submodules/${_sub_name} EXCLUDE_FROM_ALL)
+  endif()
+endmacro()
+
+
 #--- nlohmann-json -------------------------------------------------------------
-option(USE_NLOHMANN_JSON_SUBMODULE "Always use the internal copy of nlohmann_json" FALSE)
-mark_as_advanced(USE_NLOHMANN_JSON_SUBMODULE)
-if(NOT USE_NLOHMANN_JSON_SUBMODULE)
-  find_package(nlohmann_json)
-endif()
-if (nlohmann_json_FOUND)
-  # Setup the imported target alias if an older un-aliased version is found
-  if(TARGET nlohmann_json AND NOT TARGET nlohmann_json::nlohmann_json)
-    add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
-  endif()
-else()
-  set_property(CACHE USE_NLOHMANN_JSON_SUBMODULE PROPERTY VALUE TRUE)
-  message(STATUS "nlohmann_json not found, using included submodule.")
-  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/submodules/nlohmann_json/CMakeLists.txt)
-    message(FATAL_ERROR "nlohmann_json submodule is not available.")
-  endif()
-  add_subdirectory(submodules/nlohmann_json EXCLUDE_FROM_ALL)
+_prmon_add_internal_external_dependency(nlohmann_json NLOHMANN_JSON nlohmann_json)
+
+# Setup the imported target alias if an older un-aliased version is found
+if(TARGET nlohmann_json AND NOT TARGET nlohmann_json::nlohmann_json)
+  add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
 endif()
 
 #--- spdlog --------------------------------------------------------------------
-option(USE_SPDLOG_SUBMODULE "Always use the internal copy of spdlog" FALSE)
-mark_as_advanced(USE_SPDLOG_SUBMODULE)
-if(NOT USE_SPDLOG_SUBMODULE)
-  find_package(spdlog)
-endif()
-if (spdlog_FOUND)
-  message(STATUS
-          "Found spdlog: ${spdlog_CONFIG} (found version \"${spdlog_VERSION}\")")
-else()
-  set_property(CACHE USE_SPDLOG_SUBMODULE PROPERTY VALUE TRUE)
-  message(STATUS "spdlog not found, using included submodule.")
-  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/submodules/spdlog/CMakeLists.txt)
-    message(FATAL_ERROR "spdlog submodule is not available.")
-  endif()
-  add_subdirectory(submodules/spdlog EXCLUDE_FROM_ALL)
-endif()
+_prmon_add_internal_external_dependency(spdlog SPDLOG spdlog)

--- a/cmake/prmonDependencies.cmake
+++ b/cmake/prmonDependencies.cmake
@@ -1,5 +1,22 @@
 #--- nlohmann-json -------------------------------------------------------------
-find_package(nlohmann_json REQUIRED)
+option(USE_NLOHMANN_JSON_SUBMODULE "Always use the internal copy of nlohmann_json" FALSE)
+mark_as_advanced(USE_NLOHMANN_JSON_SUBMODULE)
+if(NOT USE_NLOHMANN_JSON_SUBMODULE)
+  find_package(nlohmann_json)
+endif()
+if (nlohmann_json_FOUND)
+  # Setup the imported target alias if an older un-aliased version is found
+  if(TARGET nlohmann_json AND NOT TARGET nlohmann_json::nlohmann_json)
+    add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
+  endif()
+else()
+  set_property(CACHE USE_NLOHMANN_JSON_SUBMODULE PROPERTY VALUE TRUE)
+  message(STATUS "nlohmann_json not found, using included submodule.")
+  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/submodules/nlohmann_json/CMakeLists.txt)
+    message(FATAL_ERROR "nlohmann_json submodule is not available.")
+  endif()
+  add_subdirectory(submodules/nlohmann_json EXCLUDE_FROM_ALL)
+endif()
 
 #--- spdlog --------------------------------------------------------------------
 option(USE_SPDLOG_SUBMODULE "Always use the internal copy of spdlog" FALSE)

--- a/cmake/prmonDependencies.cmake
+++ b/cmake/prmonDependencies.cmake
@@ -1,0 +1,20 @@
+#--- nlohmann-json -------------------------------------------------------------
+find_package(nlohmann_json REQUIRED)
+
+#--- spdlog --------------------------------------------------------------------
+option(USE_SPDLOG_SUBMODULE "Always use the internal copy of spdlog" FALSE)
+mark_as_advanced(USE_SPDLOG_SUBMODULE)
+if(NOT USE_SPDLOG_SUBMODULE)
+  find_package(spdlog)
+endif()
+if (spdlog_FOUND)
+  message(STATUS
+          "Found spdlog: ${spdlog_CONFIG} (found version \"${spdlog_VERSION}\")")
+else()
+  set_property(CACHE USE_SPDLOG_SUBMODULE PROPERTY VALUE TRUE)
+  message(STATUS "spdlog not found, using included submodule.")
+  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/submodules/spdlog/CMakeLists.txt)
+    message(FATAL_ERROR "spdlog submodule is not available.")
+  endif()
+  add_subdirectory(submodules/spdlog EXCLUDE_FROM_ALL)
+endif()

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(nlohmann_json REQUIRED)
-
 add_executable(prmon src/prmon.cpp
            src/prmonutils.cpp
            src/utils.cpp
@@ -13,6 +11,9 @@ add_executable(prmon src/prmon.cpp
            src/memmon.cpp
            src/nvidiamon.cpp
            )
+
+target_link_libraries(prmon PRIVATE spdlog::spdlog_header_only)
+
 if (BUILD_BENCHMARK_LOG)
   add_executable(benchmark-log benchmarks/benchmark-log.cpp)
 endif(BUILD_BENCHMARK_LOG)

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -12,18 +12,14 @@ add_executable(prmon src/prmon.cpp
            src/nvidiamon.cpp
            )
 
-target_link_libraries(prmon PRIVATE spdlog::spdlog_header_only)
+target_link_libraries(prmon PRIVATE
+           nlohmann_json::nlohmann_json
+           spdlog::spdlog_header_only
+           )
 
 if (BUILD_BENCHMARK_LOG)
   add_executable(benchmark-log benchmarks/benchmark-log.cpp)
 endif(BUILD_BENCHMARK_LOG)
-
-# Some older versions of the nlohmann_json package don't define
-# this target (< 3.0.0 ?). The build on these platforms seems to
-# go ok even without this "link library" definition.
-if(TARGET nlohmann_json::nlohmann_json)
-  target_link_libraries(prmon PRIVATE nlohmann_json::nlohmann_json)
-endif(TARGET nlohmann_json::nlohmann_json)
 
 # Set flags based on more unusual build flags
 if(BUILD_STATIC)

--- a/package/include/spdlog
+++ b/package/include/spdlog
@@ -1,1 +1,0 @@
-../../submodules/spdlog/include/spdlog


### PR DESCRIPTION
This adds support for both internal and external versions dependencies:

- `nlohmann_json` and `spdlog` are each supported now as as either externally found or internal submodules
  - submodules have been made also shallow
- Adds a reusable macro `_prmon_add_internal_external_dependency` used by both dependencies
- Adds a new configure option for each, `NLOHMANN_JSON` and `SPDLOG`:
  - `-DUSE_EXTERNAL_FOO={TRUE,FALSE,`**`AUTO`**`}`
    - `ON`, `TRUE`: Force an external version and fail if not found.
    - `OFF`, `FALSE`: Require the internal copy be used.
    - **`AUTO`**: Search for an external version and fall back to the internal copy if not found.