### PR TITLE
Update citation name and (C) year

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 # This CITATION.cff file was generated with cffinit.
 # Visit https://bit.ly/cffinit to generate yours today!
 cff-version: 1.2.0
-title: PRMon
+title: prmon
 date-released: "2018-06-08"
 message: >-
   If you use this software, please cite it using the

--- a/README.md
+++ b/README.md
@@ -249,4 +249,4 @@ to CMake using `Gperftools_ROOT_DIR`.
 
 # Copyright
 
-Copyright (c) 2018-2020 CERN.
+Copyright (c) 2018-2022 CERN.


### PR DESCRIPTION
The original citation file had an odd capitalisation - changed to be `prmon`, all lower case, as used in documentation.

Update the overall (C) year to 2022.