### PR TITLE
Fix the empty netmon description in the help message

### DIFF
--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -356,9 +356,13 @@ int main(int argc, char* argv[]) {
     std::cout << "Monitors available:" << std::endl;
     auto monitors = prmon::get_all_registered();
     for (const auto& name : monitors) {
-      std::cout << " - " << name << " : "
-                << registry::Registry<Imonitor>::get_description(name)
-                << std::endl;
+      std::cout
+          << " - " << name << " : "
+          << (name == "netmon"
+                  ? registry::Registry<Imonitor, std::vector<std::string>>::
+                        get_description(name)
+                  : registry::Registry<Imonitor>::get_description(name))
+          << std::endl;
     }
     std::cout << std::endl;
     std::cout << "More information: https://github.com/HSF/prmon\n"


### PR DESCRIPTION
Hi @graeme-a-stewart, 

I noticed that the description for `netmon` in the help message is empty:

```
Monitors available:
 - countmon : Monitor number of processes and threads
 - cpumon : Monitor cpu time used
 - iomon : Monitor input and output activity
 - memmon : Monitor memory usage
 - nvidiamon : Monitor NVIDIA GPU activity
 - wallmon : Monitor wallclock time
 - netmon : 

More information: https://github.com/HSF/prmon
```

This PR should fix it:

```
Monitors available:
 - countmon : Monitor number of processes and threads
 - cpumon : Monitor cpu time used
 - iomon : Monitor input and output activity
 - memmon : Monitor memory usage
 - nvidiamon : Monitor NVIDIA GPU activity
 - wallmon : Monitor wallclock time
 - netmon : Monitor network activity (device level)

More information: https://github.com/HSF/prmon
```

Please let me know what you think, many thanks.

Best,
Serhan