### PR TITLE
Add long option to pstree to prevent truncating

### DIFF
--- a/package/src/prmonutils.cpp
+++ b/package/src/prmonutils.cpp
@@ -38,7 +38,7 @@ std::vector<pid_t> pstree_pids(const pid_t mother_pid) {
   // method
   std::vector<pid_t> cpids;
   char smaps_buffer[64];
-  snprintf(smaps_buffer, 64, "pstree -A -p %ld | tr \\- \\\\n",
+  snprintf(smaps_buffer, 64, "pstree -l -A -p %ld | tr \\- \\\\n",
            (long)mother_pid);
   FILE *pipe = popen(smaps_buffer, "r");
   if (pipe == 0) return cpids;


### PR DESCRIPTION
Hi,

I've noticed when there are a lot of levels of nested children processes/threads, the output of ```pstree -A -p %ld | tr \\- \\\\n``` doesn't always include the pids of all the children processes, as the output of `pstree` is truncated to 132 characters (the default). A workaround this limitation is to include the flag `-l` in the call to `pstree`, which avoids truncating altogether.

Alternatively, the default column where it starts truncating could be increased, but I think this workaround is cleaner.

What do you think?

Thanks,
Miguel

