### PR TITLE
Support multiple plots

### DIFF
--- a/package/index.html
+++ b/package/index.html
@@ -1,0 +1,2 @@
+test file
+

--- a/package/index.html
+++ b/package/index.html
@@ -1,2 +1,0 @@
-test file
-

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -148,11 +148,11 @@ def check_variables(data, var, ylist):
             print(f"ERROR:: Variable {carg} is not available in one of the data sets")
 
 
-# This function does something
+# This function creates the final data set of y-values
 
 def create_list(ylist, data, args, xmult, ymult, xlabel):
     ydlist = []
-    for carg in range(len(ylist)):
+    for carg in ylist:
         if args.diff:
             num = np.array(data[carg].diff()) * ymult
             denom = np.array(data[xlabel].diff()) * xmult
@@ -162,7 +162,6 @@ def create_list(ylist, data, args, xmult, ymult, xlabel):
             ydlist.append(np.array(data[carg]) * ymult)
     return ydlist
 
-
 # Graph plotting functions
 
 def draw_stacked_graph(xdata, ydlist, ylist):
@@ -171,9 +170,12 @@ def draw_stacked_graph(xdata, ydlist, ylist):
         xdata, ydata, lw=2, labels=[LEGENDNAMES[val] for val in ylist], alpha=0.6
     )
 
-def draw_line_graph(xdata, ydlist, ylist):
+def draw_line_graph(xdata, ydlist, ylist, style):
+    colours = plt.rcParams['axes.prop_cycle'].by_key()['color']     # This is a list of the matplotlib default colours
+    count = 0
     for cidx, cdata in enumerate(ydlist):
-        plt.plot(xdata, cdata, lw=2, label=LEGENDNAMES[ylist[cidx]])
+        plt.plot(xdata, cdata, lw=2, label=LEGENDNAMES[ylist[cidx]], color=colours[count], linestyle=style)
+        count += 1
 
 
 # Main function
@@ -311,16 +313,22 @@ def main():
 
     for i in range(len(data)):
         xdata.append(np.array(data[i][xlabel] * xmultiplier))
-        ydlist.append(create_list(ylist, data, args, xmultiplier, ymultiplier, xlabel))
+        ydlist.append(create_list(ylist, data[i], args, xmultiplier, ymultiplier, xlabel))
 
     # Plots the graphs
 
+    line_styles = list(mpl.lines.lineStyles.keys())
+
     if args.stacked:
-        for i in range(xdata):
-            draw_stacked_graph(xdata[i], ydlist[i], ylist)
+        if len(ylist) == 1:
+            for i in range(len(xdata)):
+                draw_stacked_graph(xdata[i], ydlist[i], ylist)
+        else:
+            print("ERROR:: Stacked graphs are not supported for more than one data set")
+            sys.exit(-1)
     else:
-        for i in range(xdata):
-            draw_line_graph(xdata[i], ydlist[i], ylist)
+        for i in range(len(xdata)):
+            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % 7])
 
     # Creates the key
 

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -256,6 +256,10 @@ def main():
     ylist = args.yvar.split(",")
     data = []
 
+    if len(inputs) > 7:
+        print("ERROR:: Inputting more than seven sets of data is not currently supported")
+        sys.exit(-1)
+
     for i in range(len(inputs)):
         check_input_file(inputs[i])
         data.append(load_data(inputs[i]))

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -256,12 +256,6 @@ def main():
     ylist = args.yvar.split(",")
     data = []
 
-    if len(inputs) > 7:
-        print(
-            "ERROR:: Inputting more than seven sets of data is not currently supported"
-        )
-        sys.exit(-1)
-
     for i in range(len(inputs)):
         check_input_file(inputs[i])
         data.append(load_data(inputs[i]))
@@ -332,7 +326,7 @@ def main():
             sys.exit(-1)
     else:
         for i in range(len(xdata)):
-            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % 7], inputs, i)
+            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i%7], inputs, i)
 
     # Create the key
     plt.legend(loc=0)

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -169,7 +169,7 @@ def draw_stacked_graph(xdata, ydlist, ylist):
 
 def draw_line_graph(xdata, ydlist, ylist, sty, inputs, count):
     # This is a list of the matplotlib default colours
-    colours = plt.rcParams['axes.prop_cycle'].by_key()['color']
+    colours = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     for cidx, cdata in enumerate(ydlist):
         if len(inputs) == 1:
             lbl = LEGENDNAMES[ylist[cidx]]
@@ -257,7 +257,9 @@ def main():
     data = []
 
     if len(inputs) > 7:
-        print("ERROR:: Inputting more than seven sets of data is not currently supported")
+        print(
+            "ERROR:: Inputting more than seven sets of data is not currently supported"
+        )
         sys.exit(-1)
 
     for i in range(len(inputs)):

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -326,7 +326,7 @@ def main():
             sys.exit(-1)
     else:
         for i in range(len(xdata)):
-            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i%7], inputs, i)
+            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % 7], inputs, i)
 
     # Create the key
     plt.legend(loc=0)

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -326,7 +326,9 @@ def main():
             sys.exit(-1)
     else:
         for i in range(len(xdata)):
-            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % len(line_styles)], inputs, i)
+            draw_line_graph(
+                xdata[i], ydlist[i], ylist, line_styles[i % len(line_styles)], inputs, i
+            )
 
     # Create the key
     plt.legend(loc=0)

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -146,7 +146,7 @@ def check_variables(data, var, ylist):
 
 
 # This function creates the final data set of y-values
-def create_list(ylist, data, args, xmult, ymult, xlabel):
+def make_list(ylist, data, args, xmult, ymult, xlabel):
     ydlist = []
     for carg in ylist:
         if args.diff:
@@ -158,6 +158,7 @@ def create_list(ylist, data, args, xmult, ymult, xlabel):
             ydlist.append(np.array(data[carg]) * ymult)
     return ydlist
 
+
 # Graph plotting functions
 def draw_stacked_graph(xdata, ydlist, ylist):
     ydata = np.vstack(ydlist)
@@ -165,15 +166,17 @@ def draw_stacked_graph(xdata, ydlist, ylist):
         xdata, ydata, lw=2, labels=[LEGENDNAMES[val] for val in ylist], alpha=0.6
     )
 
-def draw_line_graph(xdata, ydlist, ylist, style, inputs):
-    colours = plt.rcParams['axes.prop_cycle'].by_key()['color']     # This is a list of the matplotlib default colours
-    count = 0
+
+def draw_line_graph(xdata, ydlist, ylist, sty, inputs):
+    # This is a list of the matplotlib default colours
+    colours = plt.rcParams['axes.prop_cycle'].by_key()['color']
     for cidx, cdata in enumerate(ydlist):
         if len(inputs) == 1:
-            plt.plot(xdata, cdata, lw=2, label=LEGENDNAMES[ylist[cidx]], color=colours[count], linestyle=style)
+            lbl = LEGENDNAMES[ylist[cidx]]
+            plt.plot(xdata, cdata, lw=2, label=lbl, color=colours[cidx], linestyle=sty)
         else:
-            plt.plot(xdata, cdata, lw=2, label=f"{LEGENDNAMES[ylist[cidx]]} ({inputs[cidx]})", color=colours[count], linestyle=style)
-        count += 1
+            lbl = f"{LEGENDNAMES[ylist[cidx]]} ({inputs[cidx]})"
+            plt.plot(xdata, cdata, lw=2, label=lbl, color=colours[cidx], linestyle=sty)
 
 
 def main():
@@ -189,7 +192,8 @@ def main():
         "--input",
         type=str,
         default="prmon.txt",
-        help="First PrMon TXT output that will be used as input",
+        help="PrMon TXT output(s) that will be used as input(s)"
+        " (comma separated list is accepted)",
     )
     parser.add_argument(
         "--output",
@@ -215,7 +219,7 @@ def main():
         type=str,
         default=default_yvar,
         help="name(s) of the variable(s) to be plotted in the y-axis"
-        " (comma seperated list is accepted)",
+        " (comma separated list is accepted)",
     )
     parser.add_argument(
         "--yunit",
@@ -308,7 +312,7 @@ def main():
 
     for i in range(len(data)):
         xdata.append(np.array(data[i][xlabel] * xmultiplier))
-        ydlist.append(create_list(ylist, data[i], args, xmultiplier, ymultiplier, xlabel))
+        ydlist.append(make_list(ylist, data[i], args, xmultiplier, ymultiplier, xlabel))
 
     # Plot the graphs
     line_styles = list(mpl.lines.lineStyles.keys())
@@ -340,7 +344,7 @@ def main():
     else:
         fylabel = get_axis_label(ylist[0])
         fyunit = args.yunit
-    
+
     plt.title("Plot of {} vs {}".format(fxlabel, fylabel), y=1.05)
     plt.xlabel((fxlabel + " [" + fxunit + "]") if fxunit != "1" else fxlabel)
     plt.ylabel((fylabel + " [" + fyunit + "]") if fyunit != "1" else fylabel)
@@ -349,6 +353,7 @@ def main():
 
     print(f"INFO:: Saved output into {output}")
     sys.exit(0)
+
 
 if "__main__" in __name__:
     main()

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -167,7 +167,7 @@ def draw_stacked_graph(xdata, ydlist, ylist):
     )
 
 
-def draw_line_graph(xdata, ydlist, ylist, sty, inputs):
+def draw_line_graph(xdata, ydlist, ylist, sty, inputs, count):
     # This is a list of the matplotlib default colours
     colours = plt.rcParams['axes.prop_cycle'].by_key()['color']
     for cidx, cdata in enumerate(ydlist):
@@ -175,7 +175,7 @@ def draw_line_graph(xdata, ydlist, ylist, sty, inputs):
             lbl = LEGENDNAMES[ylist[cidx]]
             plt.plot(xdata, cdata, lw=2, label=lbl, color=colours[cidx], linestyle=sty)
         else:
-            lbl = f"{LEGENDNAMES[ylist[cidx]]} ({inputs[cidx]})"
+            lbl = f"{LEGENDNAMES[ylist[cidx]]} ({inputs[count]})"
             plt.plot(xdata, cdata, lw=2, label=lbl, color=colours[cidx], linestyle=sty)
 
 
@@ -326,7 +326,7 @@ def main():
             sys.exit(-1)
     else:
         for i in range(len(xdata)):
-            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % 7], inputs)
+            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % 7], inputs, i)
 
     # Create the key
     plt.legend(loc=0)

--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -326,7 +326,7 @@ def main():
             sys.exit(-1)
     else:
         for i in range(len(xdata)):
-            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % 7], inputs, i)
+            draw_line_graph(xdata[i], ydlist[i], ylist, line_styles[i % len(line_styles)], inputs, i)
 
     # Create the key
     plt.legend(loc=0)


### PR DESCRIPTION
### Multiple Plots

This allows the user to plot multiple prmon files on the same graph. 

As part of this we have divided the main function into separate sub-functions.

### Results

When graphing one set of data, the syntax of the input remains the same. The graphs on the original post are reproducible using the updated program.

Inputting multiple sets of data (by separating the filenames using commas) allows the plotting of multiple data sets on the same set of axes. For multiple data sets, dotted and dashed lines are used to distinguish each data set.

- CPU-time as a function of wall-time:

`prmon_plot.py --input prmon.txt,prmon.txt.1 --xvar wtime --yvar vmem,pss,rss,swap --yunit GB `

![test5](https://github.com/HSF/prmon/assets/93450240/1005a788-054f-40b3-81c2-3b56aa5d61ca)

- Rate of change in memory usage as a function of wall-time:

![test6](https://github.com/HSF/prmon/assets/93450240/b7654b74-52ff-4375-ae32-bac15c40f769)

Inputting up to 7  data sets is supported, although the legend does increase significantly in size and the data sets are more difficult to distinguish on the graph: it may be preferable to graph two sets of data at a time. 

-Memory as a function of wall-time using 3 data sets:

![test10](https://github.com/HSF/prmon/assets/93450240/57151146-a5fe-482e-a0e8-68cb5739a099)

### Issues

Plotting a stacked graph using multiple data sets is not supported (and will print an error) due to its lesser readability, although plotting a stacked graph using one set of data (stacking multiple variables) is still supported.

Committed by RAL Work Experience students Ismail Ryabchuk and Will Haywood under the supervision of Stewart Martin-Haugh (@StewMH).

