### PR TITLE
Make logging output file name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ The `prmon` binary is invoked with the following arguments:
 
 ```sh
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
-      [--interval 30] [--suppress-hw-info] [--units] [--netdev DEV] \
+      [--log-filename prmon.log] [--interval 30] \
+      [--suppress-hw-info] [--units] [--netdev DEV] \
       [--disable MON1] [--level LEV] [--level MON:LEV]\
       [-- prog arg arg ...]
 ```
@@ -117,6 +118,7 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
 * `--pid` the 'mother' PID to monitor (all children in the same process tree are monitored as well)
 * `--filename` output file for time-stamped monitored values
 * `--json-summmary` output file for summary data written in JSON format
+* `--log-filename` output file for log messages
 * `--interval` time, in seconds, between monitoring snapshots
 * `--suppress-hw-info` flag that turns-off hardware information collection
 * `--units` add information on units for each metric to JSON file
@@ -164,6 +166,9 @@ are given in JSON format. This file is rewritten every `interval` seconds
 with the current summary values. Use the `--units` option to see exactly
 which units are used for each metric (the value of `1` for a unit means
 it is a pure number).
+
+In the `log-filename` output file, log messages (e.g., errors, warnings etc.)
+are written.
 
 Monitoring of CPU, I/O and memory is reliably accurate, at least to within
 the sampling time. Monitoring of network I/O is **not reliable** unless the

--- a/package/src/MessageBase.h
+++ b/package/src/MessageBase.h
@@ -9,10 +9,8 @@
 
 // Global sinks
 
-static const std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
-    std::make_shared<spdlog::sinks::stdout_color_sink_st>()};
-static const std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
-    std::make_shared<spdlog::sinks::basic_file_sink_st>("prmon.log", true)};
+extern std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink;
+extern std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink;
 
 // Map from monitor to logging level
 

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -387,7 +387,8 @@ int main(int argc, char* argv[]) {
 
   // Set up the global logger
   c_sink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
-  f_sink = std::make_shared<spdlog::sinks::basic_file_sink_st>(logFileName, true);
+  f_sink =
+      std::make_shared<spdlog::sinks::basic_file_sink_st>(logFileName, true);
   spdlog::sinks_init_list s_list = {c_sink, f_sink};
   auto logger =
       std::make_shared<spdlog::logger>("prmon", s_list.begin(), s_list.end());

--- a/package/tests/test_fields.cpp
+++ b/package/tests/test_fields.cpp
@@ -29,6 +29,11 @@
 const std::string base_path = TO_STRING(PRMON_SOURCE_DIR);
 const std::string prmon_path = base_path + "/package/prmon";
 
+static const std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
+    std::make_shared<spdlog::sinks::stdout_color_sink_st>()};
+static const std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
+    std::make_shared<spdlog::sinks::basic_file_sink_st>("prmon.log", true)};
+
 bool prmon::sigusr1 = false;
 
 int run_prmon(const std::vector<std::string>& disabled_monitors) {

--- a/package/tests/test_fields.cpp
+++ b/package/tests/test_fields.cpp
@@ -29,9 +29,9 @@
 const std::string base_path = TO_STRING(PRMON_SOURCE_DIR);
 const std::string prmon_path = base_path + "/package/prmon";
 
-static const std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
+std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
     std::make_shared<spdlog::sinks::stdout_color_sink_st>()};
-static const std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
+std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
     std::make_shared<spdlog::sinks::basic_file_sink_st>("prmon.log", true)};
 
 bool prmon::sigusr1 = false;

--- a/package/tests/test_values.cpp
+++ b/package/tests/test_values.cpp
@@ -21,9 +21,9 @@ const std::vector<pid_t> mother_pid{1729};
 
 const std::string base_path = TO_STRING(TESTS_SOURCE_DIR);
 
-static const std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
+std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
     std::make_shared<spdlog::sinks::stdout_color_sink_st>()};
-static const std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
+std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
     std::make_shared<spdlog::sinks::basic_file_sink_st>("prmon.log", true)};
 
 bool prmon::sigusr1 = false;

--- a/package/tests/test_values.cpp
+++ b/package/tests/test_values.cpp
@@ -21,6 +21,11 @@ const std::vector<pid_t> mother_pid{1729};
 
 const std::string base_path = TO_STRING(TESTS_SOURCE_DIR);
 
+static const std::shared_ptr<spdlog::sinks::stdout_color_sink_st> c_sink{
+    std::make_shared<spdlog::sinks::stdout_color_sink_st>()};
+static const std::shared_ptr<spdlog::sinks::basic_file_sink_st> f_sink{
+    std::make_shared<spdlog::sinks::basic_file_sink_st>("prmon.log", true)};
+
 bool prmon::sigusr1 = false;
 
 TEST(IomonTest, IomonMonitonicityTestFixed) {


### PR DESCRIPTION
This PR addresses #215 and makes the name of the output log file name configurable via the command line option `--log-filename` (`-o`). Please let me know how it looks @graeme-a-stewart. Many thanks 😄 

Closes #215.