### PR TITLE
Add support for fast memory monitoring using smaps_rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ The `prmon` binary is invoked with the following arguments:
 prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
       [--log-filename prmon.log] [--interval 30] \
       [--suppress-hw-info] [--units] [--netdev DEV] \
-      [--disable MON1] [--level LEV] [--level MON:LEV]\
+      [--disable MON1] [--level LEV] [--level MON:LEV] \
+      [--fast-memmon] \
       [-- prog arg arg ...]
 ```
 
@@ -130,6 +131,7 @@ prmon [--pid PPP] [--filename prmon.txt] [--json-summary prmon.json] \
   * `--level LEV` sets the level for all monitors to LEV
   * `--level MON:LEV` sets the level for monitor MON to LEV
   * The valid levels are `trace`, `debug`, `info`, `warn`, `error`, `critical`
+* `--fast-memmon` toggles on fast memory monitoring using `smaps_rollup`
 * `--` after this argument the following arguments are treated as a program to invoke
   and remaining arguments are passed to it; `prmon` will then monitor this process
   instead of being given a PID via `--pid`

--- a/README.md
+++ b/README.md
@@ -143,6 +143,21 @@ incomplete arguments. If `prmon` starts a program itself (using `--`) then
 When invoked with `-h` or `--help` usage information is printed, as well as a
 list of all available monitoring components.
 
+### Fast Memory Monitoring
+
+When invoked with `--fast-memmon` `prmon` uses the `smaps_rollup` files
+that contain pre-summed memory information for each monitored process.
+This is a faster approach compared to the default behavior,
+where `prmon` aggregates the results itself by going over each of the monitored
+processes' mappings one by one.
+
+If the current kernel doesn't support `smaps_rollup` then the default
+approach is used. Users should also note that fast memory monitoring
+might not contain all metrics that the default approach supports, e.g.,
+`vmem`. In that case, the missing metric will be omitted in the output.
+If any of these issues are encountered, a relevant message is printed
+to notify the user.
+
 ### Environment Variables
 
 The `PRMON_DISABLE_MONITOR` environment variable can be used to specify a comma

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -177,4 +177,4 @@ void const memmon::do_fastmon() {
       it++;
     }
   }
-};
+}

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -18,7 +18,7 @@
 
 // Constructor; uses RAII pattern to be valid
 // after construction
-memmon::memmon() {
+memmon::memmon() : input_filename{"smaps"} {
   log_init(MONITOR_NAME);
 #undef MONITOR_NAME
   for (const auto& param : params) {
@@ -35,7 +35,8 @@ void memmon::update_stats(const std::vector<pid_t>& pids,
   std::string key_str{}, value_str{};
   for (const auto pid : pids) {
     std::stringstream smaps_fname{};
-    smaps_fname << read_path << "/proc/" << pid << "/smaps" << std::ends;
+    smaps_fname << read_path << "/proc/" << pid << "/" << input_filename.c_str()
+                << std::ends;
     std::ifstream smap_stat{smaps_fname.str()};
     while (smap_stat) {
       // Read off the potentially interesting "key: value", then discard

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -170,7 +170,7 @@ void const memmon::do_fastmon() {
   for (auto it = mem_stats.cbegin(); it != mem_stats.cend();) {
     // Delete unavailable metrics
     if (available_metrics.count(it->first) == 0) {
-      spdlog::warn("Metric " + it->first +
+      spdlog::info("Metric " + it->first +
                    " is not available in fast monitoring");
       it = mem_stats.erase(it);
     } else {

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <limits>
 #include <regex>
+#include <set>
 #include <sstream>
 
 #include "utils.h"
@@ -136,3 +137,44 @@ void const memmon::get_unit_info(nlohmann::json& unit_json) {
   prmon::fill_units(unit_json, params);
   return;
 }
+
+// Toggle on fast memmory monitoring
+void const memmon::do_fastmon() {
+  // Fast monitoring reads the data from a special file
+  // This file is called smaps_rollup instead of smaps
+  input_filename = "smaps_rollup";
+
+  // First discover all available metrics by peeking into self smaps_rollup file
+  std::set<std::string> available_metrics;
+  std::stringstream smaps_fname{"/proc/self/smaps_rollup"};
+  std::ifstream smap_stat{smaps_fname.str()};
+  std::string key_str{}, value_str{};
+  while (smap_stat) {
+    smap_stat >> key_str >> value_str;
+    smap_stat.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    if (smap_stat) {
+      if (key_str == "Size:") {
+        available_metrics.insert("vmem");
+      } else if (key_str == "Pss:") {
+        available_metrics.insert("pss");
+      } else if (key_str == "Rss:") {
+        available_metrics.insert("rss");
+      } else if (key_str == "Swap:") {
+        available_metrics.insert("swap");
+      }
+    }
+  }
+
+  // Delete unavailable metrics from the monitored stats
+  // In C++17/20 there are more elegant ways to do this
+  for (auto it = mem_stats.cbegin(); it != mem_stats.cend();) {
+    // Delete unavailable metrics
+    if (available_metrics.count(it->first) == 0) {
+      spdlog::warn("Metric " + it->first +
+                   " is not available in fast monitoring");
+      it = mem_stats.erase(it);
+    } else {
+      it++;
+    }
+  }
+};

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -26,6 +26,9 @@ class memmon final : public Imonitor, public MessageBase {
                                         {"rss", "kB", "kB"},
                                         {"swap", "kB", "kB"}};
 
+  // The input smaps file to be used
+  std::string input_filename;
+
   // Dynamic monitoring container for value measurements
   // This will be filled at initialisation, taking the names
   // from the above params
@@ -48,6 +51,9 @@ class memmon final : public Imonitor, public MessageBase {
   void const get_hardware_info(nlohmann::json& hw_json);
   void const get_unit_info(nlohmann::json& unit_json);
   bool const is_valid() { return true; }
+
+  // Toggle on fast memmory monitoring
+  inline void const do_fastmon() { input_filename = "smaps_rollup"; };
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")
 

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -53,7 +53,7 @@ class memmon final : public Imonitor, public MessageBase {
   bool const is_valid() { return true; }
 
   // Toggle on fast memmory monitoring
-  inline void const do_fastmon() { input_filename = "smaps_rollup"; };
+  void const do_fastmon();
 };
 REGISTER_MONITOR(Imonitor, memmon, "Monitor memory usage")
 

--- a/package/src/utils.cpp
+++ b/package/src/utils.cpp
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -103,4 +104,9 @@ const void prmon::fill_units(nlohmann::json& unit_json,
       unit_json["Units"]["Avg"][param.get_name()] = param.get_avg_unit();
   }
   return;
+}
+
+const bool prmon::smaps_rollup_exists() {
+  struct stat buffer;
+  return (stat("/proc/self/smaps_rollup", &buffer) == 0);
 }

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -53,6 +53,9 @@ const std::pair<int, std::vector<std::string>> cmd_pipe_output(
 //  monitor)
 const void fill_units(nlohmann::json& unit_json, const parameter_list& params);
 
+// Utility function to check if smaps_rollup is available on this machine
+const bool smaps_rollup_exists();
+
 }  // namespace prmon
 
 #endif  // PRMON_UTILS_H


### PR DESCRIPTION
This PR adds the so-called fast memory monitoring option, which uses the `smaps_rollup` file instead of the standard `smaps` file, as discussed in #219.

There are some limitation though. Most notably the `Size` metric is missing in the pre-summed file, where we get the virtual memory measurements, and the fact that `smaps_rollup` is not supported by some older kernels, e.g., `cc7`. Therefore, we probably need to do a little bit of testing before using this new mode for anything serious.

Closes #219