### PR TITLE
prmon_plot: don't use square brackets around units

### DIFF
--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -348,8 +348,8 @@ def main():
         fyunit = args.yunit
 
     plt.title("Plot of {} vs {}".format(fxlabel, fylabel), y=1.05)
-    plt.xlabel((fxlabel + " [" + fxunit + "]") if fxunit != "1" else fxlabel)
-    plt.ylabel((fylabel + " [" + fyunit + "]") if fyunit != "1" else fylabel)
+    plt.xlabel((fxlabel + " / " + fxunit) if fxunit != "1" else fxlabel)
+    plt.ylabel((fylabel + " / " + fyunit) if fyunit != "1" else fylabel)
     plt.tight_layout()
     fig.savefig(output)
 


### PR DESCRIPTION
Using square brackets around units hurts the heart of the physicist, as square brackets must only be used around quantities to denote their units (i.e. [F] = N).  The correct notation recommended by SI, ISO and DIN standards is to divide by the unit instead.

see also https://academia.stackexchange.com/a/28918 for some more references on this matter