### PR TITLE
Update the default plotting style

### DIFF
--- a/package/scripts/prmon_plot.py
+++ b/package/scripts/prmon_plot.py
@@ -13,7 +13,8 @@ try:
     mpl.use("Agg")
     import matplotlib.pyplot as plt
 
-    plt.style.use("seaborn-whitegrid")
+    if "seaborn-v0_8-whitegrid" in plt.style.available:
+        plt.style.use("seaborn-v0_8-whitegrid")
 except ImportError:
     print("ERROR:: This script needs numpy, pandas and matplotlib.")
     print("ERROR:: Looks like at least one of these modules is missing.")


### PR DESCRIPTION
It looks like `matplotlib` renamed the built-in (and outdated) `seaborn` styles (see [matplotlib/pull/22317](https://github.com/matplotlib/matplotlib/pull/22317)) in the newer releases. With this PR, the plotting script first checks if the style equivalent to what we were using exists and if so we use it. Otherwise we don't do anything special.

Closes #244 