### PR TITLE
#247: Updated copyright year in comments to 2018-2024

### DIFF
--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2024 CERN
 // License Apache2 - see LICENCE file
 
 #include "iomon.h"


### PR DESCRIPTION
I just changed the copyright year from 2018-2020 to 2018-2024 in a commented part of the code.