### PR TITLE
General update of copyright attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2018-2019 CERN
+Copyright (C) 2018-2025 CERN
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Building is usually as simple as:
 
     mkdir build
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=<installdir> <path to sources>
+    cmake -DCMAKE_INSTALL_PREFIX=<installdir> -S .. -B .
     make -j<number of cores on your machine>
     make install
 
@@ -273,4 +273,4 @@ to CMake using `Gperftools_ROOT_DIR`.
 
 # Copyright
 
-Copyright (c) 2018-2024 CERN.
+Copyright (c) 2018-2025 CERN.

--- a/package/src/Imonitor.h
+++ b/package/src/Imonitor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // PRocess MONitoring interface class

--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "countmon.h"

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Process and thread number monitoring class

--- a/package/src/cpumon.cpp
+++ b/package/src/cpumon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "cpumon.h"

--- a/package/src/cpumon.h
+++ b/package/src/cpumon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // CPU monitoring class

--- a/package/src/iomon.cpp
+++ b/package/src/iomon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "iomon.h"

--- a/package/src/iomon.h
+++ b/package/src/iomon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // I/O monitoring class

--- a/package/src/memmon.cpp
+++ b/package/src/memmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "memmon.h"

--- a/package/src/memmon.h
+++ b/package/src/memmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Memory monitoring class

--- a/package/src/netmon.cpp
+++ b/package/src/netmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "netmon.h"

--- a/package/src/netmon.h
+++ b/package/src/netmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Network monitoring class

--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2020
+// Copyright (C) 2020-2025 CERN
 
 #include "nvidiamon.h"
 

--- a/package/src/nvidiamon.h
+++ b/package/src/nvidiamon.h
@@ -1,4 +1,4 @@
-// Copyright (C) CERN, 2020
+// Copyright (C) 2020-2025 CERN
 //
 // Process and thread number monitoring class
 //

--- a/package/src/parameter.cpp
+++ b/package/src/parameter.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 CERN
+// Copyright (C) 2021-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "parameter.h"

--- a/package/src/parameter.h
+++ b/package/src/parameter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Monitored quantity class

--- a/package/src/prmon.cpp
+++ b/package/src/prmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // PRocess MONitor

--- a/package/src/prmonutils.cpp
+++ b/package/src/prmonutils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "prmonutils.h"

--- a/package/src/prmonutils.h
+++ b/package/src/prmonutils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // A few utilities handling PID operations, signals

--- a/package/src/registry.h
+++ b/package/src/registry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Implementation of a class registry that is used

--- a/package/src/utils.cpp
+++ b/package/src/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "utils.h"

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Generic header for utilities used by the prmon

--- a/package/src/wallmon.cpp
+++ b/package/src/wallmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 #include "wallmon.h"

--- a/package/src/wallmon.h
+++ b/package/src/wallmon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Wall time monitoring class

--- a/package/tests/burner.cpp
+++ b/package/tests/burner.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Simple CPU burner to simulate workload

--- a/package/tests/burner.h
+++ b/package/tests/burner.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 CERN
+// Copyright (C) 2018-2025 CERN
 // License Apache2 - see LICENCE file
 
 // Perform CPU burn maths calculations for a number of iterations

--- a/package/tests/http_block.py
+++ b/package/tests/http_block.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """Simple CGI script that delivers a known block

--- a/package/tests/net_burner.py
+++ b/package/tests/net_burner.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """Request network data for prmon unittest"""

--- a/package/tests/test_count.py
+++ b/package/tests/test_count.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """prmon test harness to count number of processes"""

--- a/package/tests/test_cpu.py
+++ b/package/tests/test_cpu.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """Test harness for process and thread burning tests"""

--- a/package/tests/test_disable.py
+++ b/package/tests/test_disable.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2020 CERN
+# Copyright (C) 2020-2025 CERN
 # License Apache2 - see LICENCE file
 
 """prmon test harness to check monitors can be disabled correctly"""

--- a/package/tests/test_exit.py
+++ b/package/tests/test_exit.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """prmon test case for monitored process exit code"""

--- a/package/tests/test_io.py
+++ b/package/tests/test_io.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """prmon test for measuring i/o"""

--- a/package/tests/test_mem.py
+++ b/package/tests/test_mem.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """prmon unitest for memory consumption"""

--- a/package/tests/test_net.py
+++ b/package/tests/test_net.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2018-2020 CERN
+# Copyright (C) 2018-2025 CERN
 # License Apache2 - see LICENCE file
 
 """Test harness script for network IO"""


### PR DESCRIPTION
Update end (C) dates to 2025 and consistently format (making future changes easier).

Closes #247 