### PR TITLE
Update minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
 # - Define the minimum CMake version
-# HSF recommends 3.3 to support C/C++ compile features for C/C++11 across all
+# HSF recommends 3.10 to support C/C++ compile features for C/C++11 across all
 # platforms
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 # - Call project() to setup system
 # From CMake 3, we can set the project version easily in one go
 project(prmon VERSION 3.1.1)
+
+# For newer CMakes use normalized install destination paths
+if(POLICY CMP0177)
+  cmake_policy(SET CMP0177 NEW)
+endif()
 
 # For newer CMakes we ensure correct handling of extracting GTest from tarball
 if (POLICY CMP0135)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ As prmon has dependencies on submodules, clone the project as
 ### Building the project
 
 Building prmon requires a C++ compiler that fully supports C++11,
-and CMake version 3.3 or higher.  It also has dependencies on:
+and CMake version 3.10 or higher.  It also has dependencies on:
 
   - [Niels Lohmann JSON libraries](https://github.com/nlohmann/json)
     - `nlohmann-json-dev` in Ubuntu 18, `nlohmann-json3-dev` in Ubuntu 20


### PR DESCRIPTION
I believe `CMake` 3.10 is a good baseline these days and our test platforms should be OK with this. Let's see if the CI concurs.

Closes #260 and #266