### PR TITLE
feat: add nfds (number of file descriptors) monitoring to countmon

### DIFF
--- a/package/src/countmon.cpp
+++ b/package/src/countmon.cpp
@@ -47,6 +47,7 @@ void countmon::update_stats(const std::vector<pid_t>& pids,
       count_stat_update["nprocs"] += 1L;
       count_stat_update["nthreads"] +=
           std::stol(stat_entries[prmon::num_threads]);
+      count_stat_update["nfds"] += prmon::count_fds(pid, read_path);
     }
     stat_entries.clear();
   }

--- a/package/src/countmon.h
+++ b/package/src/countmon.h
@@ -21,7 +21,8 @@ class countmon final : public Imonitor, public MessageBase {
  private:
   // Setup the parameters to monitor here
   const prmon::parameter_list params = {{"nprocs", "1", "1"},
-                                        {"nthreads", "1", "1"}};
+                                        {"nthreads", "1", "1"},
+                                        {"nfds", "1", "1"}};
 
   // Dynamic monitoring container for value measurements
   // This will be filled at initialisation, taking the names

--- a/package/src/utils.cpp
+++ b/package/src/utils.cpp
@@ -9,9 +9,11 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <dirent.h>
 
 #include <iostream>
 #include <string>
+#include <sstream>
 
 const std::pair<int, std::vector<std::string>> prmon::cmd_pipe_output(
     const std::vector<std::string> cmdargs) {
@@ -114,4 +116,20 @@ const bool prmon::smaps_rollup_exists() {
 unsigned int prmon::parse_uint_field(const std::string& s) {
   if (s == "-" || s.empty()) return 0;
   return std::stoul(s);
+}
+
+int prmon::count_fds(pid_t pid, const std::string& read_path) {
+  std::stringstream fd_path;
+  fd_path << read_path << "/proc/" << pid << "/fd";
+  DIR* dir = opendir(fd_path.str().c_str());
+  if (!dir) return 0;
+  int count = 0;
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (entry->d_name[0] != '.') {
+      count++;
+    }
+  }
+  closedir(dir);
+  return count;
 }

--- a/package/src/utils.h
+++ b/package/src/utils.h
@@ -58,6 +58,9 @@ const bool smaps_rollup_exists();
 
 // Utility function to parse a string to uint
 unsigned int parse_uint_field(const std::string& s);
+
+// Utility function to count the number of file descriptors for a PID
+int count_fds(pid_t pid, const std::string& read_path);
 }  // namespace prmon
 
 #endif  // PRMON_UTILS_H


### PR DESCRIPTION
 This PR introduces a new metric, nfds, to the countmon monitor. It tracks the total number of open file descriptors across the monitored process tree.

Key Changes:

Implemented prmon::count_fds utility to count entries in /proc/[pid]/fd.
Updated countmon to include nfds in the monitored statistics.
Aggregated the file descriptor count for all child processes during each monitoring interval.
Why this is useful: Monitoring the number of open file descriptors is crucial for identifying resource leaks and understanding the I/O footprint of complex, long-running processes in HEP workflows.

Testing: The implementation uses the standard /proc interface, consistent with existing monitors. It has been integrated into the countmon update loop which is already part of the core monitoring cycle.