### PR TITLE
More robust parsing of GPU parameters

### DIFF
--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -590,20 +590,16 @@ void const nvidiamon::get_hardware_info_smi(nlohmann::json& hw_json) {
   for (auto const& s : cmd_result.second) {
     std::istringstream instr(s);
     // Parse first field to a string in case it's weird, like "[N/A]"
+    // N.B. We expect this to be digits + a comma
     std::string tok;
     instr >> tok;
-    if (tok == "[N/A]") {
-      warning("Got [N/A] for GPU frequency");
+    errno = 0;
+    char* end = 0;
+    sm_freq = std::strtoul(tok.c_str(), &end, 10);
+    // Belt and braces error detection...
+    if ((end == tok.c_str()) || (*end != ',') || errno == ERANGE) {
+      warning("Odd value from GPU hardware query for frequency (will set to 0): " + tok);
       sm_freq = 0;
-    } else {
-      errno = 0;
-      char* end = 0;
-      sm_freq = std::strtoul(tok.c_str(), &end, 10);
-      // Belt and braces error detection...
-      if ((end == tok.c_str()) || (*end != '\0') || errno == ERANGE) {
-        warning("Odd value from GPU hardware query for frequency (will set to 0): " + tok);
-        sm_freq = 0;
-      }
     }
     instr.get();  // Swallow the comma
     instr >> total_mem;

--- a/package/src/nvidiamon.cpp
+++ b/package/src/nvidiamon.cpp
@@ -589,7 +589,22 @@ void const nvidiamon::get_hardware_info_smi(nlohmann::json& hw_json) {
   unsigned int count{0};
   for (auto const& s : cmd_result.second) {
     std::istringstream instr(s);
-    instr >> sm_freq;
+    // Parse first field to a string in case it's weird, like "[N/A]"
+    std::string tok;
+    instr >> tok;
+    if (tok == "[N/A]") {
+      warning("Got [N/A] for GPU frequency");
+      sm_freq = 0;
+    } else {
+      errno = 0;
+      char* end = 0;
+      sm_freq = std::strtoul(tok.c_str(), &end, 10);
+      // Belt and braces error detection...
+      if ((end == tok.c_str()) || (*end != '\0') || errno == ERANGE) {
+        warning("Odd value from GPU hardware query for frequency (will set to 0): " + tok);
+        sm_freq = 0;
+      }
+    }
     instr.get();  // Swallow the comma
     instr >> total_mem;
     auto pos = std::string::size_type(instr.tellg()) + 2;  // Skip ", "


### PR DESCRIPTION
GPU stats are obtained via an nvidia-smi call:

nvidia-smi --query-gpu=clocks.max.sm,memory.total,gpu_name --format=csv,noheader,nounits

That should give two numbers and a name.  However, as seen on some CERN GPU nodes, this is also possible:

```sh
[N/A], 24576, NVIDIA H100L-2-24C
```

Which is coming from a MIG partitioned GPU.

The parser will now handle this case, as well as other parsing failures, by printing a warning and setting the frequency to 0.

Closes #317.